### PR TITLE
lttng: add v4l2 tracing support

### DIFF
--- a/recipes-kernel/lttng-2.0/lttng-modules/0001-lttng-modules-Add-V4L2-tracepoints.patch
+++ b/recipes-kernel/lttng-2.0/lttng-modules/0001-lttng-modules-Add-V4L2-tracepoints.patch
@@ -1,0 +1,186 @@
+From f64b9b50c36726544eb4ee5c1f2429bf0eb2d811 Mon Sep 17 00:00:00 2001
+From: Wade Farnsworth <wade_farnsworth@mentor.com>
+Date: Wed, 15 May 2013 10:28:28 -0700
+Subject: [PATCH] lttng-modules: Add V4L2 tracepoints
+
+Signed-off-by: Wade Farnsworth <wade_farnsworth@mentor.com>
+---
+ instrumentation/events/lttng-module/v4l2.h | 48 ++++++++++++++++++++++++++++++
+ instrumentation/events/mainline/v4l2.h     | 48 ++++++++++++++++++++++++++++++
+ probes/Makefile                            |  4 +++
+ probes/lttng-probe-v4l2.c                  | 43 ++++++++++++++++++++++++++
+ 4 files changed, 143 insertions(+)
+ create mode 100644 instrumentation/events/lttng-module/v4l2.h
+ create mode 100644 instrumentation/events/mainline/v4l2.h
+ create mode 100644 probes/lttng-probe-v4l2.c
+
+Index: git/instrumentation/events/lttng-module/v4l2.h
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ git/instrumentation/events/lttng-module/v4l2.h	2013-05-15 10:43:04.802598719 -0700
+@@ -0,0 +1,48 @@
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM v4l2
++
++#if !defined(_TRACE_V4L2_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _TRACE_V4L2_H
++
++#include <linux/tracepoint.h>
++
++TRACE_EVENT(v4l2_dqbuf,
++	TP_PROTO(int minor, struct v4l2_buffer *buf),
++
++	TP_ARGS(minor, buf),
++
++	TP_STRUCT__entry(
++		__field(int, minor)
++		__field(s64, ts)
++	),
++
++	TP_fast_assign(
++		tp_assign(minor, minor);
++		tp_assign(ts, timeval_to_ns(&buf->timestamp));
++	),
++
++	TP_printk("%d [%lld]", __entry->minor, __entry->ts)
++)
++
++TRACE_EVENT(v4l2_qbuf,
++	TP_PROTO(int minor, struct v4l2_buffer *buf),
++
++	TP_ARGS(minor, buf),
++
++	TP_STRUCT__entry(
++		__field(int, minor)
++		__field(s64, ts)
++	),
++
++	TP_fast_assign(
++		tp_assign(minor, minor);
++		tp_assign(ts, timeval_to_ns(&buf->timestamp));
++	),
++
++	TP_printk("%d [%lld]", __entry->minor, __entry->ts)
++)
++
++#endif /* if !defined(_TRACE_V4L2_H) || defined(TRACE_HEADER_MULTI_READ) */
++
++/* This part must be outside protection */
++#include "../../../probes/define_trace.h"
+Index: git/instrumentation/events/mainline/v4l2.h
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ git/instrumentation/events/mainline/v4l2.h	2013-05-15 10:40:39.043833645 -0700
+@@ -0,0 +1,48 @@
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM v4l2
++
++#if !defined(_TRACE_V4L2_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _TRACE_V4L2_H
++
++#include <linux/tracepoint.h>
++
++TRACE_EVENT(v4l2_dqbuf,
++	TP_PROTO(int minor, struct v4l2_buffer *buf),
++
++	TP_ARGS(minor, buf),
++
++	TP_STRUCT__entry(
++		__field(int, minor)
++		__field(s64, ts)
++	),
++
++	TP_fast_assign(
++		__entry->minor = minor;
++		__entry->ts = timeval_to_ns(&buf->timestamp);
++	),
++
++	TP_printk("%d [%lld]", __entry->minor, __entry->ts)
++);
++
++TRACE_EVENT(v4l2_qbuf,
++	TP_PROTO(int minor, struct v4l2_buffer *buf),
++
++	TP_ARGS(minor, buf),
++
++	TP_STRUCT__entry(
++		__field(int, minor)
++		__field(s64, ts)
++	),
++
++	TP_fast_assign(
++		__entry->minor = minor;
++		__entry->ts = timeval_to_ns(&buf->timestamp);
++	),
++
++	TP_printk("%d [%lld]", __entry->minor, __entry->ts)
++);
++
++#endif /* if !defined(_TRACE_V4L2_H) || defined(TRACE_HEADER_MULTI_READ) */
++
++/* This part must be outside protection */
++#include <trace/define_trace.h>
+Index: git/probes/Makefile
+===================================================================
+--- git.orig/probes/Makefile	2013-05-15 10:40:38.663833252 -0700
++++ git/probes/Makefile	2013-05-15 10:40:39.043833645 -0700
+@@ -102,6 +102,10 @@
+ obj-m += lttng-probe-lock.o
+ endif
+ 
++ifneq ($(CONFIG_VIDEO_V4L2),)
++obj-m += lttng-probe-v4l2.o
++endif
++
+ ifneq ($(CONFIG_KPROBES),)
+ obj-m += lttng-kprobes.o
+ endif
+Index: git/probes/lttng-probe-v4l2.c
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ git/probes/lttng-probe-v4l2.c	2013-05-15 10:44:32.213835975 -0700
+@@ -0,0 +1,44 @@
++/*
++ * probes/lttng-probe-v4l2.c
++ *
++ * LTTng v4l2 probes.
++ *
++ * Copyright (C) 2010-2012 Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
++ * Copyright (C) 2012,2013 Mentor Graphics Corp.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; only
++ * version 2.1 of the License.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include <linux/module.h>
++#include <linux/videodev2.h>
++
++/*
++ * Create the tracepoint static inlines from the kernel to validate that our
++ * trace event macros match the kernel we run on.
++ */
++#include <trace/events/v4l2.h>
++
++/*
++ * Create LTTng tracepoint probes.
++ */
++#define LTTNG_PACKAGE_BUILD
++#define CREATE_TRACE_POINTS
++#define TRACE_INCLUDE_PATH ../instrumentation/events/lttng-module
++
++#include "../instrumentation/events/lttng-module/v4l2.h"
++
++MODULE_LICENSE("GPL and additional rights");
++MODULE_AUTHOR("Wade Farnsworth <wade_farnsworth@mentor.com>");
++MODULE_DESCRIPTION("LTTng v4l2 probes");

--- a/recipes-kernel/lttng-2.0/lttng-modules_git.bbappend
+++ b/recipes-kernel/lttng-2.0/lttng-modules_git.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+PRINC := "${@int(PRINC) + 1}"
+
+SRC_URI += "\
+	   file://0001-lttng-modules-Add-V4L2-tracepoints.patch \	   
+	   "

--- a/recipes-kernel/lttng-2.0/lttng-tools/lttng-tools-Add-support-for-v4l2-probes.patch
+++ b/recipes-kernel/lttng-2.0/lttng-tools/lttng-tools-Add-support-for-v4l2-probes.patch
@@ -1,0 +1,18 @@
+lttng-tools: Add support for v4l2 probes
+
+Support insertion of this kernel module on start of the session.
+
+Signed-off-by: Wade Farnsworth <wade_farnsworth@mentor.com>
+
+Index: git/src/bin/lttng-sessiond/modprobe.c
+===================================================================
+--- git.orig/src/bin/lttng-sessiond/modprobe.c	2013-05-15 10:55:40.892586624 -0700
++++ git/src/bin/lttng-sessiond/modprobe.c	2013-05-22 12:03:53.172607690 -0700
+@@ -80,6 +80,7 @@ const struct kern_modules_param kern_modules_list[] = {
+ 	{ "lttng-probe-vmscan", 0 },
+ 	{ "lttng-probe-workqueue", 0 },
+ 	{ "lttng-probe-writeback", 0 },
++	{ "lttng-probe-v4l2", 0 },
+ };
+ 
+ /*

--- a/recipes-kernel/lttng-2.0/lttng-tools_2.3.0.bbappend
+++ b/recipes-kernel/lttng-2.0/lttng-tools_2.3.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+PRINC := "${@int(PRINC) + 1}"
+
+SRC_URI += "file://lttng-tools-Add-support-for-v4l2-probes.patch"


### PR DESCRIPTION
changes are merged from this commit;

https://github.com/MentorEmbedded/meta-thales-sophie-lite/commit/
7a43bbe41adcf22249ecfa5831783a0f5da0e677

commit is slightly modified for lttng-2.3.0

Signed-off-by: Fahad Usman fahad_usman@mentor.com
