### PR TITLE
qt5: add required dependencies

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtbase_5.0.2.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtbase_5.0.2.bbappend
@@ -5,3 +5,4 @@ SRC_URI += " \
 	"
 
 QT_CONFIG_FLAGS += " -no-c++11 -sa-trace "
+DEPENDS += "lttng-ust"

--- a/qt5-layer/recipes-qt/qt5/qtdeclarative_5.0.2.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtdeclarative_5.0.2.bbappend
@@ -3,3 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/qtdeclarative-${PV}:"
 SRC_URI += " \
 	file://0001-add_tracepoint_layer.patch \
 	"
+
+DEPENDS += "qtbase"


### PR DESCRIPTION
add dependency of lttng-ust in qtbase and that of qtbase in
qtdeclarative to resolve potential compilation failures due to missing
header files provided by the respective packages.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-1497

Signed-off-by: Fahad Usman fahad_usman@mentor.com
