### PR TITLE
lttng-{modules,tools}: add v4l probes in imx6 BSP

### DIFF
--- a/recipes-kernel/lttng/lttng-modules_2.4.0.bbappend
+++ b/recipes-kernel/lttng/lttng-modules_2.4.0.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 PRINC := "${@int(PRINC) + 1}"
 
-SRC_URI += "\
+SRC_URI_append_mx6q += "\
 file://0001-lttng-modules-Add-V4L2-tracepoints.patch \
 "
+

--- a/recipes-kernel/lttng/lttng-tools_2.4.0.bbappend
+++ b/recipes-kernel/lttng/lttng-tools_2.4.0.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-
 PRINC := "${@int(PRINC) + 1}"
 
-SRC_URI += "file://lttng-tools-Add-support-for-v4l2-probes.patch"
+SRC_URI_append_mx6q += "file://lttng-tools-Add-support-for-v4l2-probes.patch"
+


### PR DESCRIPTION
Build breaks while compiling v4l probe for BSPs where
kernel has not been instrumented for v4l tracing.
This patch enables building of v4l probes for imx6
BSP since its kernel is instrumented for v4l traces.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
