### PR TITLE
qt5.3.2: Add tracing patches for Qt 5.3.2

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtbase-5.3.2/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtbase-5.3.2/0001-add_tracepoint_layer.patch
@@ -1,7 +1,7 @@
-diff --git c/configure i/configure
-index cb8d78f..862306c 100755
---- c/configure
-+++ i/configure
+diff --git a/configure b/configure
+index d5c2b08..e2f7dd9 100755
+--- a/configure
++++ b/configure
 @@ -735,6 +735,7 @@ OPT_MAC_SDK=
  COMMERCIAL_USER=ask
  LICENSE_FILE=
@@ -24,7 +24,7 @@ index cb8d78f..862306c 100755
      *)
          UNKNOWN_OPT=yes
          ;;
-@@ -5681,7 +5689,9 @@ if [ "$CFG_WIDGETS" = "no" ]; then
+@@ -5673,7 +5681,9 @@ if [ "$CFG_WIDGETS" = "no" ]; then
      QT_CONFIG="$QT_CONFIG no-widgets"
      QCONFIG_FLAGS="$QCONFIG_FLAGS QT_NO_WIDGETS"
  fi
@@ -35,7 +35,7 @@ index cb8d78f..862306c 100755
  if [ "$XPLATFORM_MAC" = "yes" ]; then
      #On Mac we implicitly link against libz, so we
      #never use the 3rdparty stuff.
-@@ -6568,6 +6578,7 @@ report_support "    TDS .................." "$CFG_SQL_tds" plugin "plugin" yes "
+@@ -6560,6 +6570,7 @@ report_support "    TDS .................." "$CFG_SQL_tds" plugin "plugin" yes "
  report_support "  udev ..................." "$CFG_LIBUDEV"
  report_support "  xkbcommon .............." "$CFG_XKBCOMMON" system "system library" qt "bundled copy, XKB config root: $CFG_XKB_CONFIG_ROOT"
  report_support "  zlib ..................." "$CFG_ZLIB" system "system library" yes "bundled copy"
@@ -43,19 +43,19 @@ index cb8d78f..862306c 100755
  
  echo
  
-diff --git c/mkspecs/features/tracesupport.prf i/mkspecs/features/tracesupport.prf
+diff --git a/mkspecs/features/tracesupport.prf b/mkspecs/features/tracesupport.prf
 new file mode 100644
 index 0000000..d94a437
 --- /dev/null
-+++ i/mkspecs/features/tracesupport.prf
++++ b/mkspecs/features/tracesupport.prf
 @@ -0,0 +1,3 @@
 +DEFINES += ENABLE_SA_TRACE
 +CFLAGS          += -g3 -O1
 +LIBS            += -L$$[QT_INSTALL_LIBS] -lQt5TraceSupport -ldl -llttng-ust -lurcu-bp
-diff --git c/src/corelib/animation/qabstractanimation.cpp i/src/corelib/animation/qabstractanimation.cpp
-index 95d7713..a539807 100644
---- c/src/corelib/animation/qabstractanimation.cpp
-+++ i/src/corelib/animation/qabstractanimation.cpp
+diff --git a/src/corelib/animation/qabstractanimation.cpp b/src/corelib/animation/qabstractanimation.cpp
+index 95d7713..c3c744a 100644
+--- a/src/corelib/animation/qabstractanimation.cpp
++++ b/src/corelib/animation/qabstractanimation.cpp
 @@ -155,6 +155,10 @@
  #include <QtCore/qcoreevent.h>
  #include <QtCore/qpointer.h>
@@ -78,29 +78,18 @@ index 95d7713..a539807 100644
      time.invalidate();
      driver = &defaultDriver;
  }
-@@ -341,6 +349,10 @@ void QUnifiedTimer::restart()
- 
- void QUnifiedTimer::setTimingInterval(int interval)
- {
-+#ifdef ENABLE_SA_TRACE
-+    qt_tracepoint(Qt, qtAnimTimingInterval, interval);
-+#endif // ENABLE_SA_TRACE
-+
-     timingInterval = interval;
- 
-     if (driver->isRunning() && !pauseTimer.isActive()) {
-@@ -572,6 +584,10 @@ void QAnimationTimer::updateAnimationsTime(qint64 delta)
-     //it might happen in some cases that the time doesn't change because events are delayed
-     //when the CPU load is high
-     if (delta) {
+@@ -284,6 +292,10 @@ void QUnifiedTimer::updateAnimationTimers(qint64 currentTick)
+     //* it might happen in some cases that the delta is negative because the animation driver
+     //  advances faster than time.elapsed()
+     if (delta > 0) {
 +#ifdef ENABLE_SA_TRACE
 +        qt_tracepoint(Qt, qtAnimTick, 1);
 +#endif // ENABLE_SA_TRACE
 +
          insideTick = true;
-         for (currentAnimationIdx = 0; currentAnimationIdx < animations.count(); ++currentAnimationIdx) {
-             QAbstractAnimation *animation = animations.at(currentAnimationIdx);
-@@ -581,6 +597,10 @@ void QAnimationTimer::updateAnimationsTime(qint64 delta)
+         if (profilerCallback)
+             profilerCallback(delta);
+@@ -293,6 +305,10 @@ void QUnifiedTimer::updateAnimationTimers(qint64 currentTick)
          }
          insideTick = false;
          currentAnimationIdx = 0;
@@ -111,6 +100,17 @@ index 95d7713..a539807 100644
      }
  }
  
+@@ -341,6 +357,10 @@ void QUnifiedTimer::restart()
+ 
+ void QUnifiedTimer::setTimingInterval(int interval)
+ {
++#ifdef ENABLE_SA_TRACE
++    qt_tracepoint(Qt, qtAnimTimingInterval, interval);
++#endif // ENABLE_SA_TRACE
++    
+     timingInterval = interval;
+ 
+     if (driver->isRunning() && !pauseTimer.isActive()) {
 @@ -828,6 +848,10 @@ bool QAnimationDriver::isRunning() const
  
  void QAnimationDriver::start()
@@ -133,10 +133,10 @@ index 95d7713..a539807 100644
  }
  
  
-diff --git c/src/corelib/corelib.pro i/src/corelib/corelib.pro
+diff --git a/src/corelib/corelib.pro b/src/corelib/corelib.pro
 index 812aee3..c116a3c 100644
---- c/src/corelib/corelib.pro
-+++ i/src/corelib/corelib.pro
+--- a/src/corelib/corelib.pro
++++ b/src/corelib/corelib.pro
 @@ -32,6 +32,9 @@ ANDROID_PERMISSIONS = \
  
  load(qt_module)
@@ -147,10 +147,10 @@ index 812aee3..c116a3c 100644
  include(animation/animation.pri)
  include(arch/arch.pri)
  include(global/global.pri)
-diff --git c/src/corelib/kernel/qcoreapplication.cpp i/src/corelib/kernel/qcoreapplication.cpp
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
 index 6868eb6..52f9f0d 100644
---- c/src/corelib/kernel/qcoreapplication.cpp
-+++ i/src/corelib/kernel/qcoreapplication.cpp
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
 @@ -112,6 +112,11 @@
  
  #include <algorithm>
@@ -197,10 +197,10 @@ index 6868eb6..52f9f0d 100644
      // Make it possible for Qt Script to hook into events even
      // though QApplication is subclassed...
      bool result = false;
-diff --git c/src/gui/gui.pro i/src/gui/gui.pro
+diff --git a/src/gui/gui.pro b/src/gui/gui.pro
 index af84eb7..f9c8728 100644
---- c/src/gui/gui.pro
-+++ i/src/gui/gui.pro
+--- a/src/gui/gui.pro
++++ b/src/gui/gui.pro
 @@ -46,6 +46,8 @@ include(opengl/opengl.pri)
  include(animation/animation.pri)
  include(itemmodels/itemmodels.pri)
@@ -210,10 +210,10 @@ index af84eb7..f9c8728 100644
  QMAKE_LIBS += $$QMAKE_LIBS_GUI
  
  load(cmake_functions)
-diff --git c/src/gui/image/qimagereader.cpp i/src/gui/image/qimagereader.cpp
-index a10198a..331e972 100644
---- c/src/gui/image/qimagereader.cpp
-+++ i/src/gui/image/qimagereader.cpp
+diff --git a/src/gui/image/qimagereader.cpp b/src/gui/image/qimagereader.cpp
+index 091837b..0478bbc 100644
+--- a/src/gui/image/qimagereader.cpp
++++ b/src/gui/image/qimagereader.cpp
 @@ -152,6 +152,11 @@
  
  #include <algorithm>
@@ -248,8 +248,8 @@ index a10198a..331e972 100644
          return false;
      }
  
-@@ -1252,6 +1265,10 @@ bool QImageReader::read(QImage *image)
-            image->setDevicePixelRatio(2.0);
+@@ -1251,6 +1264,10 @@ bool QImageReader::read(QImage *image)
+         image->setDevicePixelRatio(2.0);
      }
  
 +#ifdef ENABLE_SA_TRACE
@@ -259,11 +259,11 @@ index a10198a..331e972 100644
      return true;
  }
  
-diff --git c/src/gui/kernel/qguiapplication.cpp i/src/gui/kernel/qguiapplication.cpp
-index 7648233..5716cca 100644
---- c/src/gui/kernel/qguiapplication.cpp
-+++ i/src/gui/kernel/qguiapplication.cpp
-@@ -109,6 +109,11 @@
+diff --git a/src/gui/kernel/qguiapplication.cpp b/src/gui/kernel/qguiapplication.cpp
+index 1894dbf..6fba095 100644
+--- a/src/gui/kernel/qguiapplication.cpp
++++ b/src/gui/kernel/qguiapplication.cpp
+@@ -105,6 +105,11 @@
  
  #include <ctype.h>
  
@@ -275,7 +275,7 @@ index 7648233..5716cca 100644
  QT_BEGIN_NAMESPACE
  
  Q_GUI_EXPORT bool qt_is_gui_used = true;
-@@ -1487,6 +1492,35 @@ int QGuiApplication::exec()
+@@ -1454,6 +1459,35 @@ int QGuiApplication::exec()
  */
  bool QGuiApplication::notify(QObject *object, QEvent *event)
  {
@@ -311,10 +311,10 @@ index 7648233..5716cca 100644
  #ifndef QT_NO_SHORTCUT
      if (event->type() == QEvent::KeyPress) {
          // Try looking for a Shortcut before sending key events
-diff --git c/src/src.pro i/src/src.pro
+diff --git a/src/src.pro b/src/src.pro
 index 6a805a6..3ae220b 100644
---- c/src/src.pro
-+++ i/src/src.pro
+--- a/src/src.pro
++++ b/src/src.pro
 @@ -117,7 +117,11 @@ src_plugins.depends = src_sql src_xml src_network
  
  src_android.subdir = $$PWD/android
@@ -327,19 +327,19 @@ index 6a805a6..3ae220b 100644
  SUBDIRS += src_tools_bootstrap src_tools_moc src_tools_rcc src_corelib src_tools_qlalr
  TOOLS = src_tools_moc src_tools_rcc src_tools_qlalr
  win32:SUBDIRS += src_winmain
-diff --git c/src/tracesupport/qt_tracepoints.c i/src/tracesupport/qt_tracepoints.c
+diff --git a/src/tracesupport/qt_tracepoints.c b/src/tracesupport/qt_tracepoints.c
 new file mode 100644
 index 0000000..121df3d
 --- /dev/null
-+++ i/src/tracesupport/qt_tracepoints.c
++++ b/src/tracesupport/qt_tracepoints.c
 @@ -0,0 +1,2 @@
 +#define TRACEPOINT_CREATE_PROBES
 +#include "qt_tracepoints.h"
-diff --git c/src/tracesupport/qt_tracepoints.h i/src/tracesupport/qt_tracepoints.h
+diff --git a/src/tracesupport/qt_tracepoints.h b/src/tracesupport/qt_tracepoints.h
 new file mode 100644
 index 0000000..f1e33ba
 --- /dev/null
-+++ i/src/tracesupport/qt_tracepoints.h
++++ b/src/tracesupport/qt_tracepoints.h
 @@ -0,0 +1,85 @@
 +#undef TRACEPOINT_PROVIDER
 +#define TRACEPOINT_PROVIDER         Qt
@@ -426,11 +426,11 @@ index 0000000..f1e33ba
 +#endif /* _QT_TRACEPOINTS_H */
 +
 +#include <lttng/tracepoint-event.h>
-diff --git c/src/tracesupport/tracesupport.pro i/src/tracesupport/tracesupport.pro
+diff --git a/src/tracesupport/tracesupport.pro b/src/tracesupport/tracesupport.pro
 new file mode 100644
 index 0000000..858f75d
 --- /dev/null
-+++ i/src/tracesupport/tracesupport.pro
++++ b/src/tracesupport/tracesupport.pro
 @@ -0,0 +1,22 @@
 +TARGET  = QtTraceSupport
 +CONFIG += create_prl
@@ -454,10 +454,10 @@ index 0000000..858f75d
 +
 +
 +
-diff --git c/src/widgets/graphicsview/qgraphicsscene.cpp i/src/widgets/graphicsview/qgraphicsscene.cpp
+diff --git a/src/widgets/graphicsview/qgraphicsscene.cpp b/src/widgets/graphicsview/qgraphicsscene.cpp
 index bccdb1f..85c189e 100644
---- c/src/widgets/graphicsview/qgraphicsscene.cpp
-+++ i/src/widgets/graphicsview/qgraphicsscene.cpp
+--- a/src/widgets/graphicsview/qgraphicsscene.cpp
++++ b/src/widgets/graphicsview/qgraphicsscene.cpp
 @@ -251,6 +251,10 @@
  #include <private/qgesturemanager_p.h>
  #include <private/qpathclipper_p.h>
@@ -480,11 +480,11 @@ index bccdb1f..85c189e 100644
      Q_D(QGraphicsScene);
  
      switch (event->type()) {
-diff --git c/src/widgets/kernel/qapplication.cpp i/src/widgets/kernel/qapplication.cpp
-index 04d3982..e93b4eb 100644
---- c/src/widgets/kernel/qapplication.cpp
-+++ i/src/widgets/kernel/qapplication.cpp
-@@ -103,6 +103,11 @@ extern bool qt_wince_is_pocket_pc();  //qguifunctions_wince.cpp
+diff --git a/src/widgets/kernel/qapplication.cpp b/src/widgets/kernel/qapplication.cpp
+index 0b983e7..8c3a0d7 100644
+--- a/src/widgets/kernel/qapplication.cpp
++++ b/src/widgets/kernel/qapplication.cpp
+@@ -106,6 +106,11 @@ extern bool qt_wince_is_pocket_pc();  //qguifunctions_wince.cpp
  
  #include <qpa/qplatformwindow.h>
  
@@ -496,7 +496,7 @@ index 04d3982..e93b4eb 100644
  //#define ALIEN_DEBUG
  
  static void initResources()
-@@ -2480,6 +2485,10 @@ bool QApplicationPrivate::sendMouseEvent(QWidget *receiver, QMouseEvent *event,
+@@ -2503,6 +2508,10 @@ bool QApplicationPrivate::sendMouseEvent(QWidget *receiver, QMouseEvent *event,
      Q_ASSERT(nativeWidget);
      Q_ASSERT(buttonDown);
  
@@ -507,7 +507,7 @@ index 04d3982..e93b4eb 100644
      if (alienWidget && !isAlien(alienWidget))
          alienWidget = 0;
  
-@@ -2955,6 +2964,13 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
+@@ -2978,6 +2987,13 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
      case QEvent::KeyPress:
      case QEvent::KeyRelease:
          {
@@ -521,7 +521,7 @@ index 04d3982..e93b4eb 100644
              bool isWidget = receiver->isWidgetType();
              bool isGraphicsWidget = false;
  #ifndef QT_NO_GRAPHICSVIEW
-@@ -3003,6 +3019,10 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
+@@ -3026,6 +3042,10 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
  #endif
              }
              qt_in_tab_key_event = false;
@@ -532,7 +532,7 @@ index 04d3982..e93b4eb 100644
          }
          break;
      case QEvent::MouseButtonPress:
-@@ -3077,6 +3097,10 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
+@@ -3100,6 +3120,10 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
  
              mouse->setAccepted(eventAccepted);
  
@@ -543,10 +543,10 @@ index 04d3982..e93b4eb 100644
              if (e->type() == QEvent::MouseMove) {
                  if (!pw)
                      break;
-diff --git c/src/widgets/kernel/qwidgetbackingstore.cpp i/src/widgets/kernel/qwidgetbackingstore.cpp
+diff --git a/src/widgets/kernel/qwidgetbackingstore.cpp b/src/widgets/kernel/qwidgetbackingstore.cpp
 index 9d024fd..3f09639 100644
---- c/src/widgets/kernel/qwidgetbackingstore.cpp
-+++ i/src/widgets/kernel/qwidgetbackingstore.cpp
+--- a/src/widgets/kernel/qwidgetbackingstore.cpp
++++ b/src/widgets/kernel/qwidgetbackingstore.cpp
 @@ -64,6 +64,10 @@
  #  include <qpa/qplatformnativeinterface.h>
  #endif
@@ -580,11 +580,11 @@ index 9d024fd..3f09639 100644
  }
  
  #ifndef QT_NO_PAINT_DEBUG
-diff --git c/src/widgets/widgets.pro i/src/widgets/widgets.pro
-index b12e283..183a03e 100644
---- c/src/widgets/widgets.pro
-+++ i/src/widgets/widgets.pro
-@@ -32,6 +32,7 @@ include(util/util.pri)
+diff --git a/src/widgets/widgets.pro b/src/widgets/widgets.pro
+index 0b289c7..c7790d5 100644
+--- a/src/widgets/widgets.pro
++++ b/src/widgets/widgets.pro
+@@ -31,6 +31,7 @@ include(util/util.pri)
  include(statemachine/statemachine.pri)
  include(effects/effects.pri)
  
@@ -592,10 +592,10 @@ index b12e283..183a03e 100644
  
  QMAKE_LIBS += $$QMAKE_LIBS_GUI
  
-diff --git c/sync.profile i/sync.profile
-index 690de60..cc2b9a9 100644
---- c/sync.profile
-+++ i/sync.profile
+diff --git a/sync.profile b/sync.profile
+index 9823aa1..af3d232 100644
+--- a/sync.profile
++++ b/sync.profile
 @@ -16,6 +16,7 @@
      "QtANGLE/EGL" => "!$basedir/src/3rdparty/angle/include/EGL",
      "QtZlib" => "!$basedir/src/3rdparty/zlib",

--- a/qt5-layer/recipes-qt/qt5/qtdeclarative-5.3.2/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtdeclarative-5.3.2/0001-add_tracepoint_layer.patch
@@ -1,16 +1,16 @@
-diff --git c/src/qml/qml.pro i/src/qml/qml.pro
+diff --git a/src/qml/qml.pro b/src/qml/qml.pro
 index 17d35f8..6ef177b 100644
---- c/src/qml/qml.pro
-+++ i/src/qml/qml.pro
+--- a/src/qml/qml.pro
++++ b/src/qml/qml.pro
 @@ -40,3 +40,4 @@ include(qml/qml.pri)
  include(debugger/debugger.pri)
  include(animations/animations.pri)
  include(types/types.pri)
 +contains(QT_CONFIG,tracesupport):CONFIG += tracesupport
-diff --git c/src/qml/qml/qqmlbinding.cpp i/src/qml/qml/qqmlbinding.cpp
-index 571d783..e5e54c0 100644
---- c/src/qml/qml/qqmlbinding.cpp
-+++ i/src/qml/qml/qqmlbinding.cpp
+diff --git a/src/qml/qml/qqmlbinding.cpp b/src/qml/qml/qqmlbinding.cpp
+index 571d783..43b2047 100644
+--- a/src/qml/qml/qqmlbinding.cpp
++++ b/src/qml/qml/qqmlbinding.cpp
 @@ -56,6 +56,10 @@
  #include <QVariant>
  #include <QtCore/qdebug.h>
@@ -27,7 +27,7 @@ index 571d783..e5e54c0 100644
  
      if (!updatingFlag()) {
 +#ifdef ENABLE_SA_TRACE
-+        qt_tracepoint(Qt, qtQmlFrameBind, 1, qPrintable(m_url));
++        qt_tracepoint(Qt, qtQmlFrameBind, 1, qPrintable(url));
 +#endif // ENABLE_SA_TRACE
 +
          QQmlBindingProfiler prof(ep->profiler, url, lineNo, columnNo);
@@ -39,15 +39,15 @@ index 571d783..e5e54c0 100644
              setUpdatingFlag(false);
 +
 +#ifdef ENABLE_SA_TRACE
-+        qt_tracepoint(Qt, qtQmlFrameBind, 0, qPrintable(m_url));
++        qt_tracepoint(Qt, qtQmlFrameBind, 0, qPrintable(url));
 +#endif // ENABLE_SA_TRACE
      } else {
          QQmlProperty p = property();
          QQmlAbstractBinding::printBindingLoopError(p);
-diff --git c/src/qml/qml/qqmlcomponent.cpp i/src/qml/qml/qqmlcomponent.cpp
-index 89ab353..9b75123 100644
---- c/src/qml/qml/qqmlcomponent.cpp
-+++ i/src/qml/qml/qqmlcomponent.cpp
+diff --git a/src/qml/qml/qqmlcomponent.cpp b/src/qml/qml/qqmlcomponent.cpp
+index 39a7d89..51d17cc 100644
+--- a/src/qml/qml/qqmlcomponent.cpp
++++ b/src/qml/qml/qqmlcomponent.cpp
 @@ -85,6 +85,10 @@
              "} catch(e) {}"\
          "})"
@@ -59,7 +59,7 @@ index 89ab353..9b75123 100644
  
  namespace {
      QThreadStorage<int> creationDepth;
-@@ -878,6 +882,10 @@ QQmlComponentPrivate::beginCreate(QQmlContextData *context)
+@@ -874,6 +878,10 @@ QQmlComponentPrivate::beginCreate(QQmlContextData *context)
  
      QQmlEnginePrivate *enginePriv = QQmlEnginePrivate::get(engine);
  
@@ -70,7 +70,7 @@ index 89ab353..9b75123 100644
      enginePriv->inProgressCreations++;
      state.errors.clear();
      state.completePending = true;
-@@ -970,6 +978,10 @@ void QQmlComponentPrivate::completeCreate()
+@@ -966,6 +974,10 @@ void QQmlComponentPrivate::completeCreate()
      if (state.completePending) {
          QQmlEnginePrivate *ep = QQmlEnginePrivate::get(engine);
          complete(ep, &state);
@@ -81,10 +81,10 @@ index 89ab353..9b75123 100644
      }
  
      if (depthIncreased) {
-diff --git c/src/qml/qml/qqmlengine.cpp i/src/qml/qml/qqmlengine.cpp
-index 9bf983a..a6bee46 100644
---- c/src/qml/qml/qqmlengine.cpp
-+++ i/src/qml/qml/qqmlengine.cpp
+diff --git a/src/qml/qml/qqmlengine.cpp b/src/qml/qml/qqmlengine.cpp
+index 0424c57..6bf6854 100644
+--- a/src/qml/qml/qqmlengine.cpp
++++ b/src/qml/qml/qqmlengine.cpp
 @@ -113,6 +113,11 @@
  #endif
  #endif
@@ -121,10 +121,10 @@ index 9bf983a..a6bee46 100644
      }
  }
  
-diff --git c/src/qml/qml/qqmltypeloader.cpp i/src/qml/qml/qqmltypeloader.cpp
-index 4412f95..dcfd5cc 100644
---- c/src/qml/qml/qqmltypeloader.cpp
-+++ i/src/qml/qml/qqmltypeloader.cpp
+diff --git a/src/qml/qml/qqmltypeloader.cpp b/src/qml/qml/qqmltypeloader.cpp
+index 7fc08bd..401430a 100644
+--- a/src/qml/qml/qqmltypeloader.cpp
++++ b/src/qml/qml/qqmltypeloader.cpp
 @@ -64,6 +64,10 @@
  #include <QtCore/qwaitcondition.h>
  #include <QtQml/qqmlextensioninterface.h>
@@ -136,7 +136,7 @@ index 4412f95..dcfd5cc 100644
  #if defined (Q_OS_UNIX)
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -934,6 +938,10 @@ void QQmlDataLoader::load(QQmlDataBlob *blob, Mode mode)
+@@ -927,6 +931,10 @@ void QQmlDataLoader::load(QQmlDataBlob *blob, Mode mode)
  #endif
      blob->startLoading(this);
  
@@ -147,7 +147,7 @@ index 4412f95..dcfd5cc 100644
      if (m_thread->isThisThread()) {
          unlock();
          loadThread(blob);
-@@ -1058,6 +1066,9 @@ void QQmlDataLoader::loadThread(QQmlDataBlob *blob)
+@@ -1045,6 +1053,9 @@ void QQmlDataLoader::loadThread(QQmlDataBlob *blob)
                  if (blob->m_data.isAsync())
                      m_thread->callDownloadProgressChanged(blob, 1.);
                  setData(blob, debugCache.value(url, QByteArray()));
@@ -157,7 +157,7 @@ index 4412f95..dcfd5cc 100644
                  return;
              }
          }
-@@ -1080,6 +1091,9 @@ void QQmlDataLoader::loadThread(QQmlDataBlob *blob)
+@@ -1067,6 +1078,9 @@ void QQmlDataLoader::loadThread(QQmlDataBlob *blob)
  
          setData(blob, &file);
  
@@ -167,7 +167,7 @@ index 4412f95..dcfd5cc 100644
      } else {
  
          QNetworkReply *reply = m_thread->networkAccessManager()->get(QNetworkRequest(blob->m_url));
-@@ -1141,6 +1155,10 @@ void QQmlDataLoader::networkReplyFinished(QNetworkReply *reply)
+@@ -1128,6 +1142,10 @@ void QQmlDataLoader::networkReplyFinished(QNetworkReply *reply)
          setData(blob, data);
      }
  
@@ -178,7 +178,7 @@ index 4412f95..dcfd5cc 100644
      blob->release();
  }
  
-@@ -2107,6 +2125,10 @@ void QQmlTypeData::unregisterCallback(TypeDataCallback *callback)
+@@ -2094,6 +2112,10 @@ void QQmlTypeData::unregisterCallback(TypeDataCallback *callback)
  
  void QQmlTypeData::done()
  {
@@ -189,7 +189,7 @@ index 4412f95..dcfd5cc 100644
      // Check all script dependencies for errors
      for (int ii = 0; !isError() && ii < m_scripts.count(); ++ii) {
          const ScriptReference &script = m_scripts.at(ii);
-@@ -2344,6 +2366,10 @@ void QQmlTypeData::compile()
+@@ -2331,6 +2353,10 @@ void QQmlTypeData::compile()
  {
      Q_ASSERT(m_compiledData == 0);
  
@@ -200,9 +200,9 @@ index 4412f95..dcfd5cc 100644
      m_compiledData = new QQmlCompiledData(typeLoader()->engine());
      m_compiledData->url = finalUrl();
      m_compiledData->name = finalUrlString();
-@@ -2823,6 +2849,10 @@ void QQmlScriptBlob::initializeFromCompilationUnit(QV4::CompiledData::Compilatio
-             return;
-         }
+@@ -2343,6 +2369,10 @@ void QQmlTypeData::compile()
+         m_compiledData->release();
+         m_compiledData = 0;
      }
 +
 +#ifdef ENABLE_SA_TRACE
@@ -210,11 +210,11 @@ index 4412f95..dcfd5cc 100644
 +#endif // ENABLE_SA_TRACE
  }
  
- QQmlQmldirData::QQmlQmldirData(const QUrl &url, QQmlTypeLoader *loader)
-diff --git c/src/quick/items/qquickwindow.cpp i/src/quick/items/qquickwindow.cpp
-index 17b8440..39ddd3d 100644
---- c/src/quick/items/qquickwindow.cpp
-+++ i/src/quick/items/qquickwindow.cpp
+ void QQmlTypeData::resolveTypes()
+diff --git a/src/quick/items/qquickwindow.cpp b/src/quick/items/qquickwindow.cpp
+index e78f914..5f5a5b4 100644
+--- a/src/quick/items/qquickwindow.cpp
++++ b/src/quick/items/qquickwindow.cpp
 @@ -73,6 +73,11 @@
  #include <private/qqmlprofilerservice_p.h>
  #include <private/qqmlmemoryprofiler_p.h>
@@ -227,7 +227,7 @@ index 17b8440..39ddd3d 100644
  QT_BEGIN_NAMESPACE
  
  extern Q_GUI_EXPORT QImage qt_gl_read_framebuffer(const QSize &size, bool alpha_format, bool include_alpha);
-@@ -1291,6 +1296,11 @@ bool QQuickWindow::event(QEvent *e)
+@@ -1290,6 +1295,11 @@ bool QQuickWindow::event(QEvent *e)
  {
      Q_D(QQuickWindow);
  
@@ -239,29 +239,18 @@ index 17b8440..39ddd3d 100644
      switch (e->type()) {
  
      case QEvent::TouchBegin:
-@@ -1354,6 +1364,10 @@ void QQuickWindow::keyPressEvent(QKeyEvent *e)
- {
-     Q_D(QQuickWindow);
-     d->deliverKeyEvent(e);
+@@ -1389,6 +1399,10 @@ void QQuickWindowPrivate::deliverKeyEvent(QKeyEvent *e)
+             QGuiApplication::sendEvent(focusWindow, e);
+     }
+ #endif
 +
 +#ifdef ENABLE_SA_TRACE
 +    qt_tracepoint(Qt, qtKeyEventConsumed, e->type(), e->key(), e->modifiers());
 +#endif // ENABLE_SA_TRACE
  }
  
- /*! \reimp */
-@@ -1361,6 +1375,10 @@ void QQuickWindow::keyReleaseEvent(QKeyEvent *e)
- {
-     Q_D(QQuickWindow);
-     d->deliverKeyEvent(e);
-+
-+#ifdef ENABLE_SA_TRACE
-+    qt_tracepoint(Qt, qtKeyEventConsumed, e->type(), e->key(), e->modifiers());
-+#endif // ENABLE_SA_TRACE
- }
- 
- void QQuickWindowPrivate::deliverKeyEvent(QKeyEvent *e)
-@@ -1458,6 +1476,11 @@ bool QQuickWindowPrivate::deliverMouseEvent(QMouseEvent *event)
+ QMouseEvent *QQuickWindowPrivate::cloneMouseEvent(QMouseEvent *event, QPointF *transformedLocalPos)
+@@ -1457,6 +1471,11 @@ bool QQuickWindowPrivate::deliverMouseEvent(QMouseEvent *event)
              event->accept();
          else
              event->ignore();
@@ -273,7 +262,7 @@ index 17b8440..39ddd3d 100644
          return event->isAccepted();
      }
  
-@@ -1467,10 +1490,19 @@ bool QQuickWindowPrivate::deliverMouseEvent(QMouseEvent *event)
+@@ -1466,10 +1485,19 @@ bool QQuickWindowPrivate::deliverMouseEvent(QMouseEvent *event)
          me->accept();
          q->sendEvent(mouseGrabberItem, me.data());
          event->setAccepted(me->isAccepted());
@@ -294,7 +283,7 @@ index 17b8440..39ddd3d 100644
      return false;
  }
  
-@@ -1507,6 +1539,10 @@ void QQuickWindow::mouseReleaseEvent(QMouseEvent *event)
+@@ -1506,6 +1534,10 @@ void QQuickWindow::mouseReleaseEvent(QMouseEvent *event)
  
      if (!d->mouseGrabberItem) {
          QWindow::mouseReleaseEvent(event);
@@ -305,7 +294,7 @@ index 17b8440..39ddd3d 100644
          return;
      }
  
-@@ -1534,6 +1570,10 @@ void QQuickWindow::mouseDoubleClickEvent(QMouseEvent *event)
+@@ -1533,6 +1565,10 @@ void QQuickWindow::mouseDoubleClickEvent(QMouseEvent *event)
              event->accept();
          else
              event->ignore();
@@ -316,7 +305,7 @@ index 17b8440..39ddd3d 100644
          return;
      }
  
-@@ -1587,6 +1627,10 @@ void QQuickWindow::mouseMoveEvent(QMouseEvent *event)
+@@ -1586,6 +1622,10 @@ void QQuickWindow::mouseMoveEvent(QMouseEvent *event)
              accepted = d->clearHover();
          }
          event->setAccepted(accepted);
@@ -327,10 +316,10 @@ index 17b8440..39ddd3d 100644
          return;
      }
  
-diff --git c/src/quick/quick.pro i/src/quick/quick.pro
+diff --git a/src/quick/quick.pro b/src/quick/quick.pro
 index 38e743c..0bdba7c 100644
---- c/src/quick/quick.pro
-+++ i/src/quick/quick.pro
+--- a/src/quick/quick.pro
++++ b/src/quick/quick.pro
 @@ -29,6 +29,7 @@ include(util/util.pri)
  include(scenegraph/scenegraph.pri)
  include(items/items.pri)
@@ -339,10 +328,10 @@ index 38e743c..0bdba7c 100644
  
  HEADERS += \
      qtquickglobal.h \
-diff --git c/src/quick/scenegraph/coreapi/qsgrenderer.cpp i/src/quick/scenegraph/coreapi/qsgrenderer.cpp
+diff --git a/src/quick/scenegraph/coreapi/qsgrenderer.cpp b/src/quick/scenegraph/coreapi/qsgrenderer.cpp
 index a4e122e..2135734 100644
---- c/src/quick/scenegraph/coreapi/qsgrenderer.cpp
-+++ i/src/quick/scenegraph/coreapi/qsgrenderer.cpp
+--- a/src/quick/scenegraph/coreapi/qsgrenderer.cpp
++++ b/src/quick/scenegraph/coreapi/qsgrenderer.cpp
 @@ -56,6 +56,10 @@
  
  #include <private/qquickprofiler_p.h>

--- a/qt5-layer/recipes-qt/qt5/qtquick1-5.3.2/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtquick1-5.3.2/0001-add_tracepoint_layer.patch
@@ -1,8 +1,8 @@
 diff --git a/src/declarative/declarative.pro b/src/declarative/declarative.pro
-index 476ef8d..9e2d2da 100644
+index 70bfd35..f2db3b5 100644
 --- a/src/declarative/declarative.pro
 +++ b/src/declarative/declarative.pro
-@@ -25,6 +25,7 @@ include(qml/qml.pri)
+@@ -27,6 +27,7 @@ include(qml/qml.pri)
  include(util/util.pri)
  include(graphicsitems/graphicsitems.pri)
  include(debugger/debugger.pri)
@@ -156,7 +156,7 @@ index 5546a5e..0f3fd14 100644
  
  namespace {
 diff --git a/src/declarative/qml/qdeclarativecomponent.cpp b/src/declarative/qml/qdeclarativecomponent.cpp
-index f2596cc..518ade8 100644
+index cbf23fa..226473c 100644
 --- a/src/declarative/qml/qdeclarativecomponent.cpp
 +++ b/src/declarative/qml/qdeclarativecomponent.cpp
 @@ -62,6 +62,10 @@
@@ -193,7 +193,7 @@ index f2596cc..518ade8 100644
  }
  
 diff --git a/src/declarative/qml/qdeclarativeengine.cpp b/src/declarative/qml/qdeclarativeengine.cpp
-index a42c6a0..a1ad339 100644
+index c7fc386..2f6ba37 100644
 --- a/src/declarative/qml/qdeclarativeengine.cpp
 +++ b/src/declarative/qml/qdeclarativeengine.cpp
 @@ -113,6 +113,11 @@


### PR DESCRIPTION
1. Fix for Qt Declarative patch to allow it to compile
2. Updated QtDeclarative patch to 5.3.2 (untested)
3. Updates to QtBase, QtQuick1 patches for 5.3.2

Signed-off-by: Abhijit Potnis Abhijit_Potnis@mentor.com
