### PR TITLE
Add lttng 2.5

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
 BBFILE_COLLECTIONS += "tracing-layer"
 BBFILE_PATTERN_tracing-layer = "^${LAYERDIR}/"
 BBFILE_PATTERN_IGNORE_EMPTY_tracing-layer = "1"
-BBFILE_PRIORITY_tracing-layer = "1"
+BBFILE_PRIORITY_tracing-layer = "6"

--- a/recipes-kernel/lttng/babeltrace/0001-Fix-Support-out-of-tree-builds-in-babeltrace.patch
+++ b/recipes-kernel/lttng/babeltrace/0001-Fix-Support-out-of-tree-builds-in-babeltrace.patch
@@ -1,0 +1,17 @@
+Upstream-Status: backport
+
+babeltrace: Fix support out of tree builds in babeltrace
+
+Signed-off-by: Lars Persson <larper@axis.com>
+
+diff --git a/formats/lttng-live/Makefile.am b/formats/lttng-live/Makefile.am
+index c834699..2c6b0bd 100644
+--- a/formats/lttng-live/Makefile.am
++++ b/formats/lttng-live/Makefile.am
+@@ -1,4 +1,4 @@
+-AM_CFLAGS = $(PACKAGE_CFLAGS) -I$(top_srcdir)/include -I$(top_builddir)/include
++AM_CFLAGS = $(PACKAGE_CFLAGS) -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)
+ 
+ lib_LTLIBRARIES = libbabeltrace-lttng-live.la
+ 
+

--- a/recipes-kernel/lttng/babeltrace/Fix-Align-buffers-from-objstack_alloc-on-sizeof-void.patch
+++ b/recipes-kernel/lttng/babeltrace/Fix-Align-buffers-from-objstack_alloc-on-sizeof-void.patch
@@ -1,0 +1,54 @@
+From cae67efbd9ddf2cee6bbefec076dc8933ababc43 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fredrik=20Markstr=C3=B6m?= <fredrik.markstrom@gmail.com>
+Date: Fri, 16 May 2014 10:10:38 +0800
+Subject: [PATCH] Fix: Align buffers from objstack_alloc on sizeof(void *)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream-Status: Backport
+
+The buffers from objstack_alloc will store pointers, so they must
+be aligned on a pointer's size, or else it will cause issues on the
+CPUs which do not support unaligned addresses access.
+
+Signed-off-by: Fredrik Markstrom <fredrik.markstrom@gmail.com>
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+Signed-off-by: Jérémie Galarneau <jeremie.galarneau@efficios.com>
+---
+ formats/ctf/metadata/objstack.c |    5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/formats/ctf/metadata/objstack.c b/formats/ctf/metadata/objstack.c
+index 9e264a4..14d9252 100644
+--- a/formats/ctf/metadata/objstack.c
++++ b/formats/ctf/metadata/objstack.c
+@@ -27,6 +27,7 @@
+ #include <stdlib.h>
+ #include <babeltrace/list.h>
+ #include <babeltrace/babeltrace-internal.h>
++#include <babeltrace/align.h>
+ 
+ #define OBJSTACK_INIT_LEN		128
+ #define OBJSTACK_POISON			0xcc
+@@ -39,7 +40,7 @@ struct objstack_node {
+ 	struct bt_list_head node;
+ 	size_t len;
+ 	size_t used_len;
+-	char data[];
++	char __attribute__ ((aligned (sizeof(void *)))) data[];
+ };
+ 
+ BT_HIDDEN
+@@ -118,6 +119,8 @@ void *objstack_alloc(struct objstack *objstack, size_t len)
+ 	struct objstack_node *last_node;
+ 	void *p;
+ 
++	len = ALIGN(len, sizeof(void *));
++
+ 	/* Get last node */
+ 	last_node = bt_list_entry(objstack->head.prev,
+ 			struct objstack_node, node);
+-- 
+1.7.10.4
+

--- a/recipes-kernel/lttng/babeltrace_1.2.1.bb
+++ b/recipes-kernel/lttng/babeltrace_1.2.1.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Babeltrace - Trace Format Babel Tower"
+DESCRIPTION = "Babeltrace provides trace read and write libraries in host side, as well as a trace converter, which used to convert LTTng 2.0 traces into human-readable log."
+HOMEPAGE = "http://www.efficios.com/babeltrace/"
+BUGTRACKER = "https://bugs.lttng.org/projects/babeltrace"
+
+LICENSE = "MIT & GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=76ba15dd76a248e1dd526bca0e2125fa"
+
+inherit autotools pkgconfig
+
+DEPENDS = "glib-2.0 util-linux popt bison-native flex-native"
+
+SRCREV = "66c2a20b4391fb5c7f870aeb0dde854f0ae1fc79"
+PV = "1.2.1+git${SRCPV}"
+
+SRC_URI = "git://git.efficios.com/babeltrace.git;branch=stable-1.2 \
+           file://0001-Fix-Support-out-of-tree-builds-in-babeltrace.patch \
+           file://Fix-Align-buffers-from-objstack_alloc-on-sizeof-void.patch \
+"
+
+S = "${WORKDIR}/git"
+
+do_configure_prepend () {
+	( cd ${S}; ${S}/bootstrap )
+}

--- a/recipes-kernel/lttng/lttng-modules/Fix-noargs-probes-should-calculate-alignment-and-eve.patch
+++ b/recipes-kernel/lttng/lttng-modules/Fix-noargs-probes-should-calculate-alignment-and-eve.patch
@@ -1,0 +1,130 @@
+Upstream-Status: Backport
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+
+From d3de7f1468be0b18145ff85b3c1a7c7fb1d48c15 Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Fri, 25 Jul 2014 12:30:43 -0400
+Subject: [PATCH 1/3] Fix: noargs probes should calculate alignment and event
+ length
+
+A noargs probe could have event fields. noargs just means that the probe
+does not receive any argument as parameter. However, it could very well
+serialize data into fields (global variables, constants, etc).
+
+It just happens that LTTng does not serialize any data in noargs events
+at the moment, but this may very well change.
+
+The if (0) with (void) variable access strategy to stop compiler from
+complaining from unused variables does not seem to work as expected with
+gcc 4.9.1. Use "unused" attribute instead.
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ probes/lttng-events.h | 49 +++++++++++++++++++++++++++++++++++--------------
+ 1 file changed, 35 insertions(+), 14 deletions(-)
+
+diff --git a/probes/lttng-events.h b/probes/lttng-events.h
+index 596b70608584..ba9563b15cf9 100644
+--- a/probes/lttng-events.h
++++ b/probes/lttng-events.h
+@@ -456,10 +456,19 @@ static __used struct lttng_probe_desc TP_ID(__probe_desc___, TRACE_SYSTEM) = {
+ static inline size_t __event_get_size__##_name(size_t *__dynamic_len, _proto) \
+ {									      \
+ 	size_t __event_len = 0;						      \
+-	unsigned int __dynamic_len_idx = 0;				      \
++	unsigned int __dynamic_len_idx __attribute__((unused)) = 0;	      \
++									      \
++	_tstruct							      \
++	return __event_len;						      \
++}
++
++#undef DECLARE_EVENT_CLASS_NOARGS
++#define DECLARE_EVENT_CLASS_NOARGS(_name, _tstruct, _assign, _print)	      \
++static inline size_t __event_get_size__##_name(size_t *__dynamic_len)	      \
++{									      \
++	size_t __event_len = 0;						      \
++	unsigned int __dynamic_len_idx __attribute__((unused)) = 0;	      \
+ 									      \
+-	if (0)								      \
+-		(void) __dynamic_len_idx;	/* don't warn if unused */    \
+ 	_tstruct							      \
+ 	return __event_len;						      \
+ }
+@@ -514,6 +523,15 @@ static inline size_t __event_get_align__##_name(_proto)			      \
+ 	return __event_align;						      \
+ }
+ 
++#undef DECLARE_EVENT_CLASS_NOARGS
++#define DECLARE_EVENT_CLASS_NOARGS(_name, _tstruct, _assign, _print)	      \
++static inline size_t __event_get_align__##_name(void)			      \
++{									      \
++	size_t __event_align = 1;					      \
++	_tstruct							      \
++	return __event_align;						      \
++}
++
+ #include TRACE_INCLUDE(TRACE_INCLUDE_FILE)
+ 
+ 
+@@ -553,12 +571,16 @@ static inline size_t __event_get_align__##_name(_proto)			      \
+ #undef TP_STRUCT__entry
+ #define TP_STRUCT__entry(args...) args
+ 
+-#undef DECLARE_EVENT_CLASS
+-#define DECLARE_EVENT_CLASS(_name, _proto, _args, _tstruct, _assign, _print)  \
++#undef DECLARE_EVENT_CLASS_NOARGS
++#define DECLARE_EVENT_CLASS_NOARGS(_name, _tstruct, _assign, _print)	      \
+ struct __event_typemap__##_name {					      \
+ 	_tstruct							      \
+ };
+ 
++#undef DECLARE_EVENT_CLASS
++#define DECLARE_EVENT_CLASS(_name, _proto, _args, _tstruct, _assign, _print)  \
++	DECLARE_EVENT_CLASS_NOARGS(_name, _tstruct, _assign, _print)
++
+ #include TRACE_INCLUDE(TRACE_INCLUDE_FILE)
+ 
+ 
+@@ -760,15 +782,11 @@ static void __event_probe__##_name(void *__data, _proto)		      \
+ 	struct lttng_channel *__chan = __event->chan;			      \
+ 	struct lib_ring_buffer_ctx __ctx;				      \
+ 	size_t __event_len, __event_align;				      \
+-	size_t __dynamic_len_idx = 0;					      \
+-	size_t __dynamic_len[2 * ARRAY_SIZE(__event_fields___##_name)];	      \
+-	struct __event_typemap__##_name __typemap;			      \
++	size_t __dynamic_len_idx __attribute__((unused)) = 0;		      \
++	size_t __dynamic_len[2 * ARRAY_SIZE(__event_fields___##_name)] __attribute__((unused)); \
++	struct __event_typemap__##_name __typemap __attribute__((unused));    \
+ 	int __ret;							      \
+ 									      \
+-	if (0) {							      \
+-		(void) __dynamic_len_idx;	/* don't warn if unused */    \
+-		(void) __typemap;		/* don't warn if unused */    \
+-	}								      \
+ 	if (!_TP_SESSION_CHECK(session, __chan->session))		      \
+ 		return;							      \
+ 	if (unlikely(!ACCESS_ONCE(__chan->session->active)))		      \
+@@ -800,6 +818,9 @@ static void __event_probe__##_name(void *__data)			      \
+ 	struct lttng_channel *__chan = __event->chan;			      \
+ 	struct lib_ring_buffer_ctx __ctx;				      \
+ 	size_t __event_len, __event_align;				      \
++	size_t __dynamic_len_idx __attribute__((unused)) = 0;		      \
++	size_t __dynamic_len[2 * ARRAY_SIZE(__event_fields___##_name)] __attribute__((unused)); \
++	struct __event_typemap__##_name __typemap __attribute__((unused));    \
+ 	int __ret;							      \
+ 									      \
+ 	if (!_TP_SESSION_CHECK(session, __chan->session))		      \
+@@ -810,8 +831,8 @@ static void __event_probe__##_name(void *__data)			      \
+ 		return;							      \
+ 	if (unlikely(!ACCESS_ONCE(__event->enabled)))			      \
+ 		return;							      \
+-	__event_len = 0;						      \
+-	__event_align = 1;						      \
++	__event_len = __event_get_size__##_name(__dynamic_len);		      \
++	__event_align = __event_get_align__##_name();			      \
+ 	lib_ring_buffer_ctx_init(&__ctx, __chan->chan, __event, __event_len,  \
+ 				 __event_align, -1);			      \
+ 	__ret = __chan->ops->event_reserve(&__ctx, __event->id);	      \
+-- 
+1.8.1.2
+

--- a/recipes-kernel/lttng/lttng-modules/Update-kvm-instrumentation-compile-on-3.17-rc1.patch
+++ b/recipes-kernel/lttng/lttng-modules/Update-kvm-instrumentation-compile-on-3.17-rc1.patch
@@ -1,0 +1,46 @@
+Upstream-Status: Backport
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+
+From 458c2022e992c057bd21d02e4c77bcc7d4d6cd6c Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Thu, 21 Aug 2014 11:15:50 -0400
+Subject: [PATCH 3/3] Update kvm instrumentation: compile on 3.17-rc1
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ instrumentation/events/lttng-module/arch/x86/kvm/trace.h | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/instrumentation/events/lttng-module/arch/x86/kvm/trace.h b/instrumentation/events/lttng-module/arch/x86/kvm/trace.h
+index 2354884074eb..3c299c58a1cf 100644
+--- a/instrumentation/events/lttng-module/arch/x86/kvm/trace.h
++++ b/instrumentation/events/lttng-module/arch/x86/kvm/trace.h
+@@ -724,7 +724,7 @@ TRACE_EVENT(kvm_emulate_insn,
+ 		tp_memcpy(insn,
+ 		       vcpu->arch.emulate_ctxt.decode.fetch.data,
+ 		       15)
+-#else
++#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+ 		tp_assign(rip, vcpu->arch.emulate_ctxt.fetch.start)
+ 		tp_assign(csbase, kvm_x86_ops->get_segment_base(vcpu, VCPU_SREG_CS))
+ 		tp_assign(len, vcpu->arch.emulate_ctxt._eip
+@@ -732,6 +732,16 @@ TRACE_EVENT(kvm_emulate_insn,
+ 		tp_memcpy(insn,
+ 		       vcpu->arch.emulate_ctxt.fetch.data,
+ 		       15)
++#else
++		tp_assign(rip, vcpu->arch.emulate_ctxt._eip -
++			(vcpu->arch.emulate_ctxt.fetch.ptr -
++				vcpu->arch.emulate_ctxt.fetch.data))
++		tp_assign(csbase, kvm_x86_ops->get_segment_base(vcpu, VCPU_SREG_CS))
++		tp_assign(len, vcpu->arch.emulate_ctxt.fetch.ptr -
++			vcpu->arch.emulate_ctxt.fetch.data)
++		tp_memcpy(insn,
++		       vcpu->arch.emulate_ctxt.fetch.data,
++		       15)
+ #endif
+ 		tp_assign(flags, kei_decode_mode(vcpu->arch.emulate_ctxt.mode))
+ 		tp_assign(failed, failed)
+-- 
+1.8.1.2
+

--- a/recipes-kernel/lttng/lttng-modules/lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch
+++ b/recipes-kernel/lttng/lttng-modules/lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch
@@ -1,0 +1,81 @@
+Upstream-Status: Inappropriate [embedded specific]
+
+lttng-modules: replace KERNELDIR with KERNEL_SRC
+
+Since lttng-modules uses the default way of module.bbclass to
+build and install lttng-modules, we do this replacement for
+it as-is.
+
+Signed-off-by: Zumeng Chen <zumeng.chen@windriver.com>
+
+diff --git a/Makefile b/Makefile
+index a9d1cb1..c1b65b9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -43,19 +43,19 @@ obj-m += lib/
+ endif # CONFIG_TRACEPOINTS
+ 
+ else # KERNELRELEASE
+-	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
++	KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
+ 	PWD := $(shell pwd)
+ 	CFLAGS = $(EXTCFLAGS)
+ 
+ default:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+ 
+ modules_install:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+ 
+ clean:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+ 
+ %.i: %.c
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) $@
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) $@
+ endif # KERNELRELEASE
+diff --git a/README b/README
+index 8c5dd46..6bd3334 100644
+--- a/README
++++ b/README
+@@ -27,8 +27,8 @@ access to your full kernel source tree), and use:
+ If you need to specify the target directory to the kernel you want to build
+ against, use:
+ 
+-% KERNELDIR=path_to_kernel_dir make
+-# KERNELDIR=path_to_kernel_dir make modules_install
++% KERNEL_SRC=path_to_kernel_dir make
++# KERNEL_SRC=path_to_kernel_dir make modules_install
+ # depmod -a kernel_version
+ 
+ Use lttng-tools to control the tracer. LTTng tools should automatically load
+diff --git a/probes/Makefile b/probes/Makefile
+index 225803c..3449866 100644
+--- a/probes/Makefile
++++ b/probes/Makefile
+@@ -212,18 +212,18 @@ endif
+ endif
+ 
+ else
+-	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
++	KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
+ 	PWD := $(shell pwd)
+ 	CFLAGS = $(EXTCFLAGS)
+ 
+ default:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+ 
+ modules_install:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+ 	/sbin/depmod -a
+ 
+ clean:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+ 
+ endif

--- a/recipes-kernel/lttng/lttng-modules_2.5.6.bb
+++ b/recipes-kernel/lttng/lttng-modules_2.5.6.bb
@@ -1,0 +1,38 @@
+SECTION = "devel"
+SUMMARY = "Linux Trace Toolkit KERNEL MODULE"
+DESCRIPTION = "The lttng-modules 2.0 package contains the kernel tracer modules"
+LICENSE = "LGPLv2.1 & GPLv2 & MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1412caf5a1aa90d6a48588a4794c0eac \
+                    file://gpl-2.0.txt;md5=751419260aa954499f7abaabaa882bbe \
+                    file://lgpl-2.1.txt;md5=243b725d71bb5df4a1e5920b344b86ad"
+
+DEPENDS = "virtual/kernel"
+
+inherit module
+
+SRCREV = "feccefb64dccd227a9e13d2787d1aba53c8488d3"
+
+COMPATIBLE_HOST = '(x86_64|i.86|powerpc|aarch64|mips|arm).*-linux'
+
+SRC_URI = "git://git.lttng.org/lttng-modules.git;branch=stable-2.5 \
+           file://lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch \
+           file://Fix-noargs-probes-should-calculate-alignment-and-eve.patch \
+           file://Update-kvm-instrumentation-compile-on-3.17-rc1.patch \
+           "
+
+export INSTALL_MOD_DIR="kernel/lttng-modules"
+export KERNEL_SRC="${STAGING_KERNEL_DIR}"
+
+
+S = "${WORKDIR}/git"
+
+do_install_append() {
+	# Delete empty directories to avoid QA failures if no modules were built
+	find ${D}/lib -depth -type d -empty -exec rmdir {} \;
+}
+
+python do_package_prepend() {
+    if not os.path.exists(os.path.join(d.getVar('D', True), 'lib/modules')):
+        bb.warn("%s: no modules were created; this may be due to CONFIG_TRACEPOINTS not being enabled in your kernel." % d.getVar('PN', True))
+}
+

--- a/recipes-kernel/lttng/lttng-tools/run-ptest
+++ b/recipes-kernel/lttng/lttng-tools/run-ptest
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+make -C tests installcheck
+

--- a/recipes-kernel/lttng/lttng-tools/runtest-2.4.0.patch
+++ b/recipes-kernel/lttng/lttng-tools/runtest-2.4.0.patch
@@ -1,0 +1,27 @@
+diff --git a/Makefile.am b/Makefile.am
+index 584f59b..c2bcabd 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -12,3 +12,9 @@ dist_doc_DATA = LICENSE \
+ dist_noinst_DATA = CodingStyle
+ 
+ EXTRA_DIST = extras/lttng-bash_completion gpl-2.0.txt lgpl-2.1.txt
++
++install-ptest:
++	cp -r $(srcdir)/tests $(DESTDIR)
++	for m in $$(find $(DESTDIR)/tests -name Makefile); do \
++          sed -i -e 's|^Makefile:|_Makefile:|' $$m; \
++        done
+diff --git a/tests/run.sh b/tests/run.sh
+index c6c50fd..6455359 100755
+--- a/tests/run.sh
++++ b/tests/run.sh
+@@ -19,4 +19,7 @@
+ 
+ [ -z "$1" ] && echo "Error: No testlist. Please specify a testlist to run." && exit 1
+ 
+-prove --merge --exec '' - < $1
++prove --merge -v --exec '' - < $1 | sed \
++  -e 's|^ok \(.*\)|PASS: \1|' \
++  -e 's|^not ok \(.*\)|FAIL: \1|' \
++  | egrep -h 'PASS|FAIL'

--- a/recipes-kernel/lttng/lttng-tools/runtest.patch
+++ b/recipes-kernel/lttng/lttng-tools/runtest.patch
@@ -1,0 +1,52 @@
+diff --git a/Makefile.am b/Makefile.am
+index 584f59b..c2bcabd 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -12,3 +12,9 @@ dist_doc_DATA = LICENSE \
+ dist_noinst_DATA = CodingStyle
+ 
+ EXTRA_DIST = extras/lttng-bash_completion gpl-2.0.txt lgpl-2.1.txt
++
++install-ptest:
++	cp -r $(srcdir)/tests $(DESTDIR)
++	for m in $$(find $(DESTDIR)/tests -name Makefile); do \
++          sed -i -e 's|^Makefile:|_Makefile:|' $$m; \
++        done
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 6d5b00d..3774f9d 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -1,14 +1,17 @@
+ SUBDIRS = utils regression unit stress
+ 
+-if USE_PYTHON
+-check-am:
++installcheck-am:
+ 	./run.sh unit_tests
+ 	./run.sh fast_regression
++if USE_PYTHON
+ 	./run.sh with_bindings_regression
+-else
++endif
++
+ check-am:
+ 	./run.sh unit_tests
+ 	./run.sh fast_regression
++if USE_PYTHON
++	./run.sh with_bindings_regression
+ endif
+ 
+ dist_noinst_SCRIPTS = run.sh unit_tests fast_regression long_regression root_regression with_bindings_regression
+diff --git a/tests/run.sh b/tests/run.sh
+index c6c50fd..6455359 100755
+--- a/tests/run.sh
++++ b/tests/run.sh
+@@ -19,4 +19,7 @@
+ 
+ [ -z "$1" ] && echo "Error: No testlist. Please specify a testlist to run." && exit 1
+ 
+-prove --merge --exec '' - < $1
++prove --merge -v --exec '' - < $1 | sed \
++  -e 's|^ok \(.*\)|PASS: \1|' \
++  -e 's|^not ok \(.*\)|FAIL: \1|' \
++  | egrep -h 'PASS|FAIL'

--- a/recipes-kernel/lttng/lttng-tools_2.5.5.bb
+++ b/recipes-kernel/lttng/lttng-tools_2.5.5.bb
@@ -1,0 +1,77 @@
+SECTION = "devel"
+SUMMARY = "Linux Trace Toolkit Control"
+DESCRIPTION = "The Linux trace toolkit is a suite of tools designed \
+to extract program execution details from the Linux operating system \
+and interpret them."
+
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=01d7fc4496aacf37d90df90b90b0cac1 \
+                    file://gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://lgpl-2.1.txt;md5=0f0d71500e6a57fd24d825f33242b9ca"
+
+DEPENDS = "liburcu popt lttng-ust libxml2"
+RDEPENDS_${PN}-ptest += "make perl bash"
+
+SRCREV = "3bba18df7be17238b146fc392393cddc594cbd6a"
+PV = "v2.5.5"
+
+PYTHON_OPTION = "am_cv_python_pyexecdir='${libdir}/python${PYTHON_BASEVERSION}/site-packages' \
+                 am_cv_python_pythondir='${libdir}/python${PYTHON_BASEVERSION}/site-packages' \
+                 PYTHON_INCLUDE='-I${STAGING_INCDIR}/python${PYTHON_BASEVERSION}' \
+"
+PACKAGECONFIG ??= "lttng-ust"
+PACKAGECONFIG[python] = "--enable-python-bindings ${PYTHON_OPTION},,python swig-native"
+PACKAGECONFIG[lttng-ust] = ", --disable-lttng-ust, lttng-ust"
+
+SRC_URI = "git://git.lttng.org/lttng-tools.git;branch=stable-2.5 \
+           file://runtest-2.4.0.patch \
+           file://run-ptest \
+	  "
+
+S = "${WORKDIR}/git"
+
+inherit autotools-brokensep ptest pkgconfig
+
+export KERNELDIR="${STAGING_KERNEL_DIR}"
+
+FILES_${PN} += "${libdir}/lttng/libexec/* ${datadir}/xml/lttng \
+                ${libdir}/python${PYTHON_BASEVERSION}/site-packages/*"
+FILES_${PN}-dbg += "${libdir}/lttng/libexec/.debug \
+                    ${libdir}/python2.7/site-packages/.debug"
+FILES_${PN}-staticdev += "${libdir}/python${PYTHON_BASEVERSION}/site-packages/*.a"
+FILES_${PN}-dev += "${libdir}/python${PYTHON_BASEVERSION}/site-packages/*.la"
+
+# Since files are installed into ${libdir}/lttng/libexec we match 
+# the libexec insane test so skip it.
+# Python module needs to keep _lttng.so
+INSANE_SKIP_${PN} = "libexec dev-so"
+INSANE_SKIP_${PN}-dbg = "libexec"
+
+do_configure_prepend () {
+	# Delete a shipped m4 file that overrides our patched one
+	rm -f ${S}/config/libxml.m4
+}
+
+do_install_ptest () {
+	chmod +x ${D}${PTEST_PATH}/tests/utils/utils.sh
+	for i in `find ${D}${PTEST_PATH} -perm /u+x -type f`; do
+		sed -e "s:\$TESTDIR.*/src/bin/lttng/\$LTTNG_BIN:\$LTTNG_BIN:g" \
+		  -e "s:\$TESTDIR/../src/bin/lttng-sessiond/\$SESSIOND_BIN:\$SESSIOND_BIN:g" \
+		  -e "s:\$DIR/../src/bin/lttng-sessiond/\$SESSIOND_BIN:\$SESSIOND_BIN:g" \
+		  -e "s:\$TESTDIR/../src/bin/lttng-consumerd/:${libdir}/lttng/libexec/:g" \
+		  -e "s:\$DIR/../src/bin/lttng-consumerd/:${libdir}/lttng/libexec/:g" \
+		  -e "s:\$TESTDIR/../src/bin/lttng-relayd/\$RELAYD_BIN:\$RELAYD_BIN:g" \
+		  -e "s:\$DIR/../src/bin/lttng-sessiond/lttng-sessiond:\$SESSIOND_BIN:g" \
+		  -e "s:\$DIR/../src/bin/lttng-relayd/\$RELAYD_BIN:\$RELAYD_BIN:g" \
+		  -e "s:\$DIR/../bin/lttng-relayd/\$RELAYD_BIN:\$RELAYD_BIN:g" \
+		  -i $i
+	done
+
+	sed -e "s:src/bin/lttng-sessiond:$bindir:g" \
+	    -e "s:src/bin/lttng-consumerd:${libexecdir}/libexec/:g" \
+	-i ${D}${PTEST_PATH}/tests/regression/run-report.py
+	sed -e "s:src/bin:bin:g" -e "s:lt-::g" \
+	-i ${D}${PTEST_PATH}/tests/utils/utils.sh
+	sed -e "s:ini_config:\.libs\/ini_config:" \
+	-i ${D}${PTEST_PATH}/tests/unit/ini_config/test_ini_config
+}

--- a/recipes-kernel/lttng/lttng-ust/lttng-ust-doc-examples-disable.patch
+++ b/recipes-kernel/lttng/lttng-ust/lttng-ust-doc-examples-disable.patch
@@ -1,0 +1,18 @@
+Upstream-Status: Inappropriate [embedded specific]
+
+Don't build the doc examples - we don't need them and in fact they
+never successfully built in previous iterations of the lttng-ust
+recipe anyway.
+
+Signed-off-by: Tom Zanussi <tom.zanussi@intel.com>
+
+Index: doc/Makefile.am
+===================================================================
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . examples
++SUBDIRS = .
+ 
+ dist_man_MANS = man/lttng-gen-tp.1 \
+ 	man/lttng-ust.3 \

--- a/recipes-kernel/lttng/lttng-ust_2.5.7.bb
+++ b/recipes-kernel/lttng/lttng-ust_2.5.7.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Linux Trace Toolkit Userspace Tracer 2.x"
+DESCRIPTION = "The LTTng UST 2.x package contains the userspace tracer library to trace userspace codes."
+HOMEPAGE = "http://lttng.org/ust"
+BUGTRACKER = "https://bugs.lttng.org/projects/lttng-ust"
+
+LICENSE = "LGPLv2.1+ & MIT & GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c963eb366b781252b0bf0fdf1624d9e9 \
+                    file://snprintf/snprintf.c;endline=32;md5=d3d544959d8a3782b2e07451be0a903c \
+                    file://snprintf/various.h;endline=31;md5=89f2509b6b4682c4fc95255eec4abe44"
+
+inherit autotools lib_package
+
+DEPENDS = "liburcu util-linux"
+RDEPENDS_${PN}-bin = "python-core"
+
+# For backwards compatibility after rename
+RPROVIDES_${PN} = "lttng2-ust"
+RREPLACES_${PN} = "lttng2-ust"
+RCONFLICTS_${PN} = "lttng2-ust"
+
+SRCREV = "1eced8cc4667c48ef1342cb3e6c5a505ef90ce5d"
+PV = "2.5.7"
+PE = "2"
+
+SRC_URI = "git://git.lttng.org/lttng-ust.git;branch=stable-2.5 \
+           file://lttng-ust-doc-examples-disable.patch \
+	   "
+
+S = "${WORKDIR}/git"
+
+do_configure_prepend () {
+	( cd ${S}; ${S}/bootstrap )
+}


### PR DESCRIPTION
Sorcery Analyzer currently doesn't support lttng-2.6 trace events. Hence moving back to lttng-2.5.