### PR TITLE
qtbase: Update QT_CONFIG_FLAGS to use -c++std c++1z

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtbase_git.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtbase_git.bbappend
@@ -4,7 +4,7 @@ SRC_URI += " \
 	file://0001-add_tracepoint_layer.patch \
 	"
 
-QT_CONFIG_FLAGS += " -no-c++11 -sa-trace "
+QT_CONFIG_FLAGS += " -c++std c++1z -sa-trace "
 DEPENDS += "lttng-ust"
 
 OE_QMAKE_LINK += " -ldl -llttng-ust -lurcu-bp "


### PR DESCRIPTION
Replace -no-c++11 with -c++std c++1z. By Qt 5.7 its going
to be recommended to use c++11. And more over in Qt 5.6
-no-c++11 is deprecated. If we use this option we will face
build failure at qtmultimedia:

git/src/gsttools/qgstreamerbushelper.cpp:55:25: error: 'nullptr' was not declared in this scope
   m_intervalTimer(nullptr)

So to avoid this issue we can safely replace -no-c++11 with -c++std c++1z.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>