### PR TITLE
MEMF: Correct the flag to call sync tracepoint only one time

### DIFF
--- a/mx6q-mel-memf/recipes-kernel/linux/files/place-memf-remote-tracepoints.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/place-memf-remote-tracepoints.patch
@@ -38,7 +38,7 @@ index 1a55602..a5e0c27 100644
  
  static bool imx6q_rpmsg_virtio_notify(struct virtqueue *vq)
  {
-+	bool executed = false;
++	static bool executed = false;
 +
  	/* Notify the other core. */
  	if (vq == imx6q_rpmsg_p->vrings[0].vq)


### PR DESCRIPTION
The synchronization tracepoint should be called only one time. Therefore
add the static keyword before the flag used to check first time execution
of tracepoint.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
