### PR TITLE
lttng-modules: apply MEMF tracing related patches only when enabled

### DIFF
--- a/mx6q-mel-memf/recipes-kernel/lttng/lttng-modules_git.bbappend
+++ b/mx6q-mel-memf/recipes-kernel/lttng/lttng-modules_git.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += " \
+PATCHES_MEMF_TRACING = " \
             file://0001-lttng-adaptation-layer-for-memf-tracing.patch \
             file://0002-lttng-adaptation-layer-for-synchornization-tracing.patch \
 "
+
+SRC_URI_append = " ${@PATCHES_MEMF_TRACING if d.getVar('MEMF_TRACING', True) == '1' else ''}"


### PR DESCRIPTION
If memf tracing is disabled with MEMF_TRACING = "0" in local.conf, MEMF
tracepoint patches are not applied resulting in missing tracepoint definition
header files and lttng compilation errors. Therefore include MEMF specific
bits only when tracing is enabled.

Signed-off-by: Yasir-Khan <yasir_khan@mentor.com>