### PR TITLE
linux-mel: fix do_patch() for mx6q-remote

### DIFF
--- a/mx6q-mel-memf/recipes-kernel/linux/linux-mel_%.bbappend
+++ b/mx6q-mel-memf/recipes-kernel/linux/linux-mel_%.bbappend
@@ -14,6 +14,6 @@ python () {
                                  file://place-memf-common-tracepoints.patch")
 }
 
-SRC_URI_append_mx6q += "${MEMF_MASTER}"
-SRC_URI_append_mx6q-remote += "${MEMF_REMOTE}"
+SRC_URI_append += "${@bb.utils.contains('MACHINE_FEATURES', 'mel-master', '${MEMF_MASTER}', '', d)}"
+SRC_URI_append += "${@bb.utils.contains('MACHINE_FEATURES', 'mel-remote', '${MEMF_REMOTE}', '', d)}"
 SRC_URI_append += "${MEMF_COMMON}"


### PR DESCRIPTION
Commit e23f8c3 in meta-mx6 adds 'mx6q' in machine overrides inside
mx6q.conf which gets inherited by mx6q-remote.conf. This invalidates
the current logic in linux-mel_%.bbappend because it pulls in patches
for both master and remote in case of mx6q-remote.

Base the patch inclusion logic on $MACHINE_FEATURES instead of
$OVERRIDES so that correct patches are included in each case.

JIRA: SB-8810

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>