### PR TITLE
linux-xlnx: provide MEMF tracing support using separate file

### DIFF
--- a/xilinx-mel-memf/recipes-kernel/linux/files/0001-provide-MEMF-tracing-support-using-separate-file.patch
+++ b/xilinx-mel-memf/recipes-kernel/linux/files/0001-provide-MEMF-tracing-support-using-separate-file.patch
@@ -1,0 +1,109 @@
+From fd72975c8509ab19d175cac6ed806b5d88915fd3 Mon Sep 17 00:00:00 2001
+From: Fahad Arslan <Fahad_Arslan@mentor.com>
+Date: Sat, 25 Mar 2017 17:03:46 +0500
+Subject: [PATCH 1/1] provide MEMF tracing support using separate file
+
+Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>
+---
+ drivers/remoteproc/Makefile                |  1 +
+ drivers/remoteproc/remoteproc_tracing.c    | 40 ++++++++++++++++++++++++++++++
+ drivers/remoteproc/zynqmp_a53_remoteproc.c |  3 ---
+ drivers/rpmsg/virtio_rpmsg_bus.c           |  5 ----
+ 4 files changed, 41 insertions(+), 8 deletions(-)
+ create mode 100644 drivers/remoteproc/remoteproc_tracing.c
+
+diff --git a/drivers/remoteproc/Makefile b/drivers/remoteproc/Makefile
+index 70fa545..feb8409 100644
+--- a/drivers/remoteproc/Makefile
++++ b/drivers/remoteproc/Makefile
+@@ -7,6 +7,7 @@ remoteproc-y				:= remoteproc_core.o
+ remoteproc-y				+= remoteproc_debugfs.o
+ remoteproc-y				+= remoteproc_virtio.o
+ remoteproc-y				+= remoteproc_elf_loader.o
++remoteproc-y				+= remoteproc_tracing.o
+ obj-$(CONFIG_OMAP_REMOTEPROC)		+= omap_remoteproc.o
+ obj-$(CONFIG_STE_MODEM_RPROC)	 	+= ste_modem_rproc.o
+ obj-$(CONFIG_WKUP_M3_RPROC)		+= wkup_m3_rproc.o
+diff --git a/drivers/remoteproc/remoteproc_tracing.c b/drivers/remoteproc/remoteproc_tracing.c
+new file mode 100644
+index 0000000..07b8379
+--- /dev/null
++++ b/drivers/remoteproc/remoteproc_tracing.c
+@@ -0,0 +1,40 @@
++/*
++ * Remote Processor Tracing
++ *
++ * Copyright (C) 2017 Mentor Graphics Corporation
++ *
++ * Fahad Arslan <fahad_arslan@mentor.com>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * version 2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ */
++
++#define CREATE_TRACE_POINTS
++#include <trace/events/Synchronization.h>
++#define CREATE_TRACE_POINTS
++#include <trace/events/MEMF.h>
++
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_DeInit);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Channel_Create);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Channel_Delete);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Ept_Create);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Ept_Delete);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Tx_Start);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Tx_Stop);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Rx_Start);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Rx_Stop);
++
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_DeInit);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_State);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Deinit);
++
++EXPORT_TRACEPOINT_SYMBOL(Synchronization_TriggerSend);
+diff --git a/drivers/remoteproc/zynqmp_a53_remoteproc.c b/drivers/remoteproc/zynqmp_a53_remoteproc.c
+index 4f9f5af..d208db5 100644
+--- a/drivers/remoteproc/zynqmp_a53_remoteproc.c
++++ b/drivers/remoteproc/zynqmp_a53_remoteproc.c
+@@ -26,11 +26,8 @@
+  */
+ 
+ #include <trace/events/MEMF.h>
+-#define CREATE_TRACE_POINTS
+ #include <trace/events/Synchronization.h>
+ 
+-EXPORT_TRACEPOINT_SYMBOL(Synchronization_TriggerSend);
+-
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/err.h>
+diff --git a/drivers/rpmsg/virtio_rpmsg_bus.c b/drivers/rpmsg/virtio_rpmsg_bus.c
+index 63e423a..9daf50b 100644
+--- a/drivers/rpmsg/virtio_rpmsg_bus.c
++++ b/drivers/rpmsg/virtio_rpmsg_bus.c
+@@ -17,13 +17,8 @@
+  * GNU General Public License for more details.
+  */
+ 
+-#define CREATE_TRACE_POINTS
+ #include <trace/events/MEMF.h>
+ 
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Init);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_DeInit);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_State);
+-
+ #define pr_fmt(fmt) "%s: " fmt, __func__
+ 
+ #include <linux/kernel.h>
+-- 
+2.8.1
+

--- a/xilinx-mel-memf/recipes-kernel/linux/linux-xlnx_4.4.bbappend
+++ b/xilinx-mel-memf/recipes-kernel/linux/linux-xlnx_4.4.bbappend
@@ -7,6 +7,7 @@ python () {
                          file://0002-allow-storing-cpu-id-of-remoteproc-for-memf-tracing.patch \
                          file://0003-place-memf-common-tracepoints.patch \
                          file://0001-place-trace-points-to-R5-remoteproc-platform-driver.patch \
-                         file://0001-export-Synchronization_TriggerSend-tracepoint-to-use.patch")
+                         file://0001-export-Synchronization_TriggerSend-tracepoint-to-use.patch \
+                         file://0001-provide-MEMF-tracing-support-using-separate-file.patch")
     return
 }


### PR DESCRIPTION
Earlier CREATE_TRACE_POINTS and EXPORT_TRACEPOINT_SYMBOL were
being used from zynqmp_a53_remoteproc.c and virtio_rpmsg_bus.c.
Due to this user was unable to unload platform drivers. (SB-8924
and SB-8942)
Also, symbol exported from zynqmp_a53_remoteproc.c was being used
in zynqmp_r5_remoteproc.c causing its dependency on
zynqmp_a53_remoteproc.c (SB-8944).

Using separate file for tracing support provides cleaner solution
and fixes mentioned issues.

http://jira.alm.mentorg.com:8080/browse/SB-8924
http://jira.alm.mentorg.com:8080/browse/SB-8942
http://jira.alm.mentorg.com:8080/browse/SB-8944

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>