### PR TITLE
linux-mel: use separate file for memf tracing

### DIFF
--- a/mx6q-mel-memf/recipes-kernel/linux/files/create-and-export-tracepoints-in-memf_tracing.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/create-and-export-tracepoints-in-memf_tracing.patch
@@ -1,0 +1,60 @@
+From 3267275d6ca8d06f36472e28d652ba295c27d4ac Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Tue, 28 Mar 2017 22:10:27 +0500
+Subject: [PATCH 1/1] create and export tracepoints in memf_tracing
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ arch/arm/mach-imx/memf_tracing.c | 40 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+ create mode 100644 arch/arm/mach-imx/memf_tracing.c
+
+diff --git a/arch/arm/mach-imx/memf_tracing.c b/arch/arm/mach-imx/memf_tracing.c
+new file mode 100644
+index 0000000..d5609b6
+--- /dev/null
++++ b/arch/arm/mach-imx/memf_tracing.c
+@@ -0,0 +1,40 @@
++/*
++ * MEMF Tracing
++ *
++ * Copyright (C) 2017 Mentor Graphics Corporation
++ *
++ * Fahad Arslan <fahad_arslan@mentor.com>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * version 2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ */
++
++#define CREATE_TRACE_POINTS
++#include <trace/events/Synchronization.h>
++#define CREATE_TRACE_POINTS
++#include <trace/events/MEMF.h>
++
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_DeInit);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Channel_Create);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Channel_Delete);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Ept_Create);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Ept_Delete);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Tx_Start);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Tx_Stop);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Rx_Start);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_RPMsg_Rx_Stop);
++
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_DeInit);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_State);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Init);
++EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Deinit);
++
++EXPORT_TRACEPOINT_SYMBOL(Synchronization_TriggerSend);
+-- 
+2.8.1
+

--- a/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-or-export-tracepoints-in-virtio_rpmsg_bus.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-or-export-tracepoints-in-virtio_rpmsg_bus.patch
@@ -1,0 +1,33 @@
+From 81656af252e36c3656c49b0d62feee6e50aad07a Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Tue, 28 Mar 2017 18:59:56 +0500
+Subject: [PATCH 1/1] do not create or export tracepoints in virtio_rpmsg_bus
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ drivers/rpmsg/virtio_rpmsg_bus.c        |  7 ------
+ 1 file changed, 0 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/rpmsg/virtio_rpmsg_bus.c b/drivers/rpmsg/virtio_rpmsg_bus.c
+index 863af75..a0afbe4 100644
+--- a/drivers/rpmsg/virtio_rpmsg_bus.c
++++ b/drivers/rpmsg/virtio_rpmsg_bus.c
+@@ -17,15 +17,8 @@
+  * GNU General Public License for more details.
+  */
+ 
+-#define CREATE_TRACE_POINTS
+ #include <trace/events/MEMF.h>
+ 
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Init);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_DeInit);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_State);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Init);
+-EXPORT_TRACEPOINT_SYMBOL(MEMF_Remoteproc_Rsc_Deinit);
+-
+ #define pr_fmt(fmt) "%s: " fmt, __func__
+ 
+ #include <linux/kernel.h>
+-- 
+2.8.1
+

--- a/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-tracepoints-in-platform-driver.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-tracepoints-in-platform-driver.patch
@@ -1,0 +1,25 @@
+From 81656af252e36c3656c49b0d62feee6e50aad07a Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Tue, 28 Mar 2017 18:59:56 +0500
+Subject: [PATCH 1/1] Do not create tracepoints in platform driver
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ drivers/remoteproc/imx6q_remoteproc.c   |  1 -
+ 1 file changed, 0 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/remoteproc/imx6q_remoteproc.c b/drivers/remoteproc/imx6q_remoteproc.c
+index 4ed93a8..47b44b9 100644
+--- a/drivers/remoteproc/imx6q_remoteproc.c
++++ b/drivers/remoteproc/imx6q_remoteproc.c
+@@ -24,7 +24,6 @@
+  */
+ 
+ #include <trace/events/MEMF.h>
+-#define CREATE_TRACE_POINTS
+ #include <trace/events/Synchronization.h>
+ 
+ #include <linux/kernel.h>
+-- 
+2.8.1
+

--- a/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-tracepoints-in-rpmsg_imx6q-driver.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/do-not-create-tracepoints-in-rpmsg_imx6q-driver.patch
@@ -1,0 +1,25 @@
+From 8a74d05ad14313329f174aa471c76200cf4a6033 Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Tue, 28 Mar 2017 20:31:26 +0500
+Subject: [PATCH 1/1] do not create tracepoints in rpmsg_imx6q driver
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ drivers/rpmsg/rpmsg_imx6q_driver.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/rpmsg/rpmsg_imx6q_driver.c b/drivers/rpmsg/rpmsg_imx6q_driver.c
+index 4cc8f16..bdf8b23 100644
+--- a/drivers/rpmsg/rpmsg_imx6q_driver.c
++++ b/drivers/rpmsg/rpmsg_imx6q_driver.c
+@@ -24,7 +24,6 @@
+  */
+ 
+ #include <trace/events/MEMF.h>
+-#define CREATE_TRACE_POINTS
+ #include <trace/events/Synchronization.h>
+ 
+ #include <linux/kernel.h>
+-- 
+2.8.1
+

--- a/mx6q-mel-memf/recipes-kernel/linux/files/make-memf_tracing-part-of-kernel.patch
+++ b/mx6q-mel-memf/recipes-kernel/linux/files/make-memf_tracing-part-of-kernel.patch
@@ -1,0 +1,23 @@
+From 2265c8563a76f98a884cf20505519daea59b7eb4 Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Wed, 29 Mar 2017 00:06:36 +0500
+Subject: [PATCH 1/1] make memf_tracing part of kernel
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ arch/arm/mach-imx/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-imx/Makefile b/arch/arm/mach-imx/Makefile
+index d973b16..7cecfbb 100644
+--- a/arch/arm/mach-imx/Makefile
++++ b/arch/arm/mach-imx/Makefile
+@@ -1,4 +1,4 @@
+-obj-y := time.o cpu.o system.o irq-common.o common.o
++obj-y := time.o cpu.o system.o irq-common.o common.o memf_tracing.o
+ 
+ obj-$(CONFIG_SOC_IMX1) += clk-imx1.o mm-imx1.o
+ obj-$(CONFIG_SOC_IMX21) += clk-imx21.o mm-imx21.o
+-- 
+2.8.1
+

--- a/mx6q-mel-memf/recipes-kernel/linux/linux-mel_%.bbappend
+++ b/mx6q-mel-memf/recipes-kernel/linux/linux-mel_%.bbappend
@@ -6,14 +6,19 @@ MEMF_COMMON = ""
 
 python () {
     if d.getVar("MEMF_TRACING", True) == "1":
-        d.setVar("MEMF_MASTER", "file://place-memf-master-tracepoints.patch")
+        d.setVar("MEMF_MASTER", "file://place-memf-master-tracepoints.patch \
+                                 file://do-not-create-tracepoints-in-platform-driver.patch")
         d.setVar("MEMF_REMOTE", "file://place-memf-remote-tracepoints.patch \
                                  file://store-cpu-id-rpmsg-platform-driver.patch \
-                                 file://0001-use-smp_processor_id-instead-of-using-hardcoded-cpu-.patch")
+                                 file://0001-use-smp_processor_id-instead-of-using-hardcoded-cpu-.patch \
+                                 file://do-not-create-tracepoints-in-rpmsg_imx6q-driver.patch")
         d.setVar("MEMF_COMMON", "file://define-memf-tracepoints.patch \
                                  file://store_cpu_id_of_remoteproc.patch \
                                  file://place-memf-common-tracepoints.patch \
-                                 file://add-traces-to-rpmsg_send_offchannel_raw_large.patch")
+                                 file://add-traces-to-rpmsg_send_offchannel_raw_large.patch \
+                                 file://do-not-create-or-export-tracepoints-in-virtio_rpmsg_bus.patch \
+                                 file://create-and-export-tracepoints-in-memf_tracing.patch \
+                                 file://make-memf_tracing-part-of-kernel.patch")
 }
 
 SRC_URI_append += "${@bb.utils.contains('MACHINE_FEATURES', 'mel-master', '${MEMF_MASTER}', '', d)}"


### PR DESCRIPTION
Move CREATE_TRACE_POINTS and EXPORT_TRACEPOINT_SYMBOL out of
imx6q_remoteproc.c and virtio_rpmsg_bus.c to a separate file
remoteproc_tracing.c.

This will make unloading of platform driver possible when tracing
is enabled.

Based on commit b9c026c which fixed similar issues for xilinx.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>