### PR TITLE
lttng-modules: adaption layers for MEMF tracing

### DIFF
--- a/zynqmp-mel-memf/recipes-kernel/lttng/files/0001-lttng-adaptation-layer-for-memf-tracing.patch
+++ b/zynqmp-mel-memf/recipes-kernel/lttng/files/0001-lttng-adaptation-layer-for-memf-tracing.patch
@@ -1,0 +1,319 @@
+From c0384bab4a6a9b1c5f02d0bb80ae9f2b283edff0 Mon Sep 17 00:00:00 2001
+From: Ahsan Hussain <ahsan_hussain@mentor.com>
+Date: Thu, 12 Apr 2018 16:21:51 +0500
+Subject: [PATCH 1/3] lttng adaptation layer for memf tracing
+
+Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>
+---
+ instrumentation/events/lttng-module/MEMF.h | 268 +++++++++++++++++++++++++++++
+ probes/lttng-probe-memf.c                  |  23 +++
+ 2 files changed, 291 insertions(+)
+ create mode 100644 instrumentation/events/lttng-module/MEMF.h
+ create mode 100644 probes/lttng-probe-memf.c
+
+diff --git a/instrumentation/events/lttng-module/MEMF.h b/instrumentation/events/lttng-module/MEMF.h
+new file mode 100644
+index 0000000..cb46f84
+--- /dev/null
++++ b/instrumentation/events/lttng-module/MEMF.h
+@@ -0,0 +1,268 @@
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM MEMF
++
++#if !defined(_LTTNG_MEMF_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _LTTNG_MEMF_H
++
++#include "../../../probes/lttng-tracepoint-event.h"
++#include <linux/tracepoint.h>
++
++LTTNG_TRACEPOINT_EVENT(MEMF_Remoteproc_Init,
++
++	TP_PROTO(unsigned long Control_Block_Address, char* Firmware_Name, unsigned int CPU_ID, int Status),
++
++	TP_ARGS(Control_Block_Address, Firmware_Name, CPU_ID, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Control_Block_Address, Control_Block_Address)
++		ctf_string(Firmware_Name, Firmware_Name)
++		ctf_integer(unsigned int, CPU_ID, CPU_ID)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_Remoteproc_State,
++
++	 TP_PROTO(unsigned long Control_Block_Address, unsigned int State, int Status),
++
++	 TP_ARGS(Control_Block_Address, State, Status),
++
++	 TP_FIELDS(
++		ctf_integer(unsigned long, Control_Block_Address, Control_Block_Address)
++		ctf_integer(unsigned int, State, State)
++		ctf_integer(int, Status, Status)
++        )
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_Remoteproc_DeInit,
++
++	TP_PROTO(unsigned long Control_Block_Address, int Status),
++
++	TP_ARGS(Control_Block_Address, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Control_Block_Address, Control_Block_Address)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_Remoteproc_Rsc_Init,
++
++	TP_PROTO(unsigned long Control_Block_Address, unsigned int CPU_ID, int Status),
++
++	TP_ARGS(Control_Block_Address, CPU_ID, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Control_Block_Address, Control_Block_Address)
++		ctf_integer(unsigned int, CPU_ID, CPU_ID)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_Remoteproc_Rsc_Deinit,
++
++	TP_PROTO(unsigned long Control_Block_Address, int Status),
++
++	TP_ARGS(Control_Block_Address, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Control_Block_Address, Control_Block_Address)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Init,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address, unsigned int CPU_ID, unsigned int Role, int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address, CPU_ID, Role, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(unsigned int, CPU_ID, CPU_ID)
++		ctf_integer(unsigned int, Role, Role)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_DeInit,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address, int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address, Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Channel_Create,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address,
++		unsigned long Channel_Control_Block_Address,
++		char *Name,
++		unsigned int Source_Address,
++		unsigned int Destination_Address,
++		int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address,
++		Channel_Control_Block_Address,
++		Name,
++		Source_Address,
++		Destination_Address,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(unsigned long, Channel_Control_Block_Address, Channel_Control_Block_Address)
++		ctf_string(Name, Name)
++		ctf_integer(unsigned int, Source_Address, Source_Address)
++		ctf_integer(unsigned int, Destination_Address, Destination_Address)
++		ctf_integer(int, Status, Status)
++	 )
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Channel_Delete,
++
++	TP_PROTO(unsigned long Channel_Control_Block_Address,
++		int Status),
++
++	TP_ARGS(Channel_Control_Block_Address,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Channel_Control_Block_Address, Channel_Control_Block_Address)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Ept_Create,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address,
++		unsigned long EPT_Control_Block_Address,
++		unsigned int Address,
++		int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address,
++		EPT_Control_Block_Address,
++		Address,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(unsigned long, EPT_Control_Block_Address, EPT_Control_Block_Address)
++		ctf_integer(unsigned int, Address, Address)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Ept_Delete,
++
++	TP_PROTO(unsigned long EPT_Control_Block_Address,
++		int Status),
++
++	TP_ARGS(EPT_Control_Block_Address,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, EPT_Control_Block_Address, EPT_Control_Block_Address)
++		ctf_integer(int, Status, Status)
++	 )
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Tx_Start,
++
++	TP_PROTO(unsigned long Channel_Control_Block_Address,
++		unsigned int Source_Address,
++		unsigned int Destination_Address,
++		unsigned int Size,
++		int Status),
++
++	TP_ARGS(Channel_Control_Block_Address,
++		Source_Address,
++		Destination_Address,
++		Size,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Channel_Control_Block_Address, Channel_Control_Block_Address)
++		ctf_integer(unsigned int, Source_Address, Source_Address)
++		ctf_integer(unsigned int, Destination_Address, Destination_Address)
++		ctf_integer(unsigned int, Size, Size)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Tx_Stop,
++
++	TP_PROTO(unsigned long Channel_Control_Block_Address,
++		unsigned int Source_Address,
++		unsigned int Destination_Address,
++		unsigned int Size,
++		int Status),
++
++	TP_ARGS(Channel_Control_Block_Address,
++		Source_Address,
++		Destination_Address,
++		Size,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, Channel_Control_Block_Address, Channel_Control_Block_Address)
++		ctf_integer(unsigned int, Source_Address, Source_Address)
++		ctf_integer(unsigned int, Destination_Address, Destination_Address)
++		ctf_integer(unsigned int, Size, Size)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Rx_Start,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address,
++		unsigned int Source_Address,
++		unsigned int Destination_Address,
++		unsigned int Size,
++		int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address,
++		Source_Address,
++		Destination_Address,
++		Size,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(unsigned int, Source_Address, Source_Address)
++		ctf_integer(unsigned int, Destination_Address, Destination_Address)
++		ctf_integer(unsigned int, Size, Size)
++		ctf_integer(int, Status, Status)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(MEMF_RPMsg_Rx_Stop,
++
++	TP_PROTO(unsigned long RPMsg_Control_Block_Address,
++		unsigned int Source_Address,
++		unsigned int Destination_Address,
++		unsigned int Size,
++		int Status),
++
++	TP_ARGS(RPMsg_Control_Block_Address,
++		Source_Address,
++		Destination_Address,
++		Size,
++		Status),
++
++	TP_FIELDS(
++		ctf_integer(unsigned long, RPMsg_Control_Block_Address, RPMsg_Control_Block_Address)
++		ctf_integer(unsigned int, Source_Address, Source_Address)
++		ctf_integer(unsigned int, Destination_Address, Destination_Address)
++		ctf_integer(unsigned int, Size, Size)
++		ctf_integer(int, Status, Status)
++	)
++)
++#endif /* LTTNG_MEMF_H */
++
++/* This part must be outside protection */
++#include "../../../probes/define_trace.h"
+diff --git a/probes/lttng-probe-memf.c b/probes/lttng-probe-memf.c
+new file mode 100644
+index 0000000..f94ede3
+--- /dev/null
++++ b/probes/lttng-probe-memf.c
+@@ -0,0 +1,23 @@
++#include <linux/module.h>
++#include "../lttng-tracer.h"
++
++/* Build time verification of mismatch between mainline TRACE_EVENT()
++ * arguments and LTTng adaptation layer LTTNG_TRACEPOINT_EVENT() arguments.
++ */
++
++/* create LTTng tracepoint probes */
++#define LTTNG_PACKAGE_BUILD
++#define CREATE_TRACE_POINTS
++#define TRACE_INCLUDE_PATH ../instrumentation/events/lttng-module
++
++#include "../instrumentation/events/lttng-module/MEMF.h"
++
++MODULE_LICENSE("GPL and additional rights");
++MODULE_AUTHOR("Fahad Arslan <fahad_arslan@mentor.com>");
++MODULE_DESCRIPTION("LTTng MEMF probes");
++MODULE_VERSION(__stringify(LTTNG_MODULES_MAJOR_VERSION) "."
++    __stringify(LTTNG_MODULES_MINOR_VERSION) "."
++    __stringify(LTTNG_MODULES_PATCHLEVEL_VERSION)
++    LTTNG_MODULES_EXTRAVERSION);
++
++
+-- 
+2.8.1
+

--- a/zynqmp-mel-memf/recipes-kernel/lttng/files/0002-lttng-adaptation-layer-for-memf-synchronization.patch
+++ b/zynqmp-mel-memf/recipes-kernel/lttng/files/0002-lttng-adaptation-layer-for-memf-synchronization.patch
@@ -1,0 +1,101 @@
+From e7c82ba6af57be441cac9d8e7a1a1e1355d4249f Mon Sep 17 00:00:00 2001
+From: Ahsan Hussain <ahsan_hussain@mentor.com>
+Date: Thu, 12 Apr 2018 16:22:37 +0500
+Subject: [PATCH 2/3] lttng adaptation layer for memf synchronization
+
+Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>
+---
+ .../events/lttng-module/Synchronization.h          | 51 ++++++++++++++++++++++
+ probes/lttng-probe-Synchronization.c               | 22 ++++++++++
+ 2 files changed, 73 insertions(+)
+ create mode 100644 instrumentation/events/lttng-module/Synchronization.h
+ create mode 100644 probes/lttng-probe-Synchronization.c
+
+diff --git a/instrumentation/events/lttng-module/Synchronization.h b/instrumentation/events/lttng-module/Synchronization.h
+new file mode 100644
+index 0000000..4983f75
+--- /dev/null
++++ b/instrumentation/events/lttng-module/Synchronization.h
+@@ -0,0 +1,51 @@
++#undef TRACE_SYSTEM
++#define TRACE_SYSTEM Synchronization
++
++#if !defined(_LTTNG_SYNCHRONIZATION_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _LTTNG_SYNCHRONIZATION_H
++
++#include "../../../probes/lttng-tracepoint-event.h"
++#include <linux/tracepoint.h>
++
++LTTNG_TRACEPOINT_EVENT(
++    /* format identical to mainline version for those */
++    /* "Synchronization" is the subsystem name, "TriggerSend" is the event name */
++    Synchronization_TriggerSend,
++
++    /* tracepoint function prototype */
++    TP_PROTO(unsigned int Priority, unsigned int CorrelationId, const char *Name),
++
++    /* arguments for this tracepoint */
++    TP_ARGS(Priority, CorrelationId, Name),
++
++    /* notice the use of ctf_integer()/tp_strcpy() and no semicolons */
++    TP_FIELDS(
++        ctf_integer(unsigned int, Priority, Priority)
++        ctf_integer(unsigned int, CorrelationId, CorrelationId)
++        ctf_string(Name, Name)
++    )
++)
++
++LTTNG_TRACEPOINT_EVENT(
++    /* format identical to mainline version for those */
++    /* "Synchronization" is the subsystem name, "TriggerReceive" is the event name */
++    Synchronization_TriggerReceive,
++
++    /* tracepoint function prototype */
++    TP_PROTO(unsigned int Priority, unsigned int CorrelationId, const char *Name),
++
++    /* arguments for this tracepoint */
++    TP_ARGS(Priority, CorrelationId, Name),
++
++    /* notice the use of ctf_integer()/tp_strcpy() and no semicolons */
++    TP_FIELDS(
++        ctf_integer(unsigned int, Priority, Priority)
++        ctf_integer(unsigned int, CorrelationId, CorrelationId)
++        ctf_string(Name, Name)
++    )
++)
++
++#endif /* !defined(_LTTNG_SYNCHRONIZATION_H) || defined(TRACE_HEADER_MULTI_READ) */
++
++/* other difference: do NOT include <trace/define_trace.h> */
++#include "../../../probes/define_trace.h"
+diff --git a/probes/lttng-probe-Synchronization.c b/probes/lttng-probe-Synchronization.c
+new file mode 100644
+index 0000000..be92d65
+--- /dev/null
++++ b/probes/lttng-probe-Synchronization.c
+@@ -0,0 +1,22 @@
++#include <linux/module.h>
++#include "../lttng-tracer.h"
++
++/*
++ * Build-time verification of mismatch between mainline TRACE_EVENT()
++ * arguments and LTTng adaptation layer LTTNG_TRACEPOINT_EVENT() arguments.
++ */
++
++/* create LTTng tracepoint probes */
++#define LTTNG_PACKAGE_BUILD
++#define CREATE_TRACE_POINTS
++#define TRACE_INCLUDE_PATH ../instrumentation/events/lttng-module
++
++#include "../instrumentation/events/lttng-module/Synchronization.h"
++
++MODULE_LICENSE("GPL and additional rights");
++MODULE_AUTHOR("Abdur Rehman <abdur_rehman@mentor.com>");
++MODULE_DESCRIPTION("LTTng Synchronization probes");
++MODULE_VERSION(__stringify(LTTNG_MODULES_MAJOR_VERSION) "."
++    __stringify(LTTNG_MODULES_MINOR_VERSION) "."
++    __stringify(LTTNG_MODULES_PATCHLEVEL_VERSION)
++    LTTNG_MODULES_EXTRAVERSION);
+-- 
+2.8.1
+

--- a/zynqmp-mel-memf/recipes-kernel/lttng/files/0003-enable-building-the-added-lttng-modules.patch
+++ b/zynqmp-mel-memf/recipes-kernel/lttng/files/0003-enable-building-the-added-lttng-modules.patch
@@ -1,0 +1,27 @@
+From e3da44dc939b29256f2c70940ea79a80082f6540 Mon Sep 17 00:00:00 2001
+From: Ahsan Hussain <ahsan_hussain@mentor.com>
+Date: Thu, 12 Apr 2018 16:25:16 +0500
+Subject: [PATCH 3/3] enable building the added lttng modules
+
+Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>
+---
+ probes/Kbuild | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/probes/Kbuild b/probes/Kbuild
+index d5d159a..1b9276a 100644
+--- a/probes/Kbuild
++++ b/probes/Kbuild
+@@ -261,4 +261,9 @@ ifneq ($(CONFIG_DYNAMIC_FTRACE),)
+   endif
+ endif # CONFIG_DYNAMIC_FTRACE
+ 
++ifneq ($(CONFIG_MEMF),)
++    obj-$(CONFIG_LTTNG) += lttng-probe-memf.o
++    obj-$(CONFIG_LTTNG) += lttng-probe-Synchronization.o
++endif # CONFIG_MEMF
++
+ # vim:syntax=make
+-- 
+2.8.1
+

--- a/zynqmp-mel-memf/recipes-kernel/lttng/lttng-modules_git.bbappend
+++ b/zynqmp-mel-memf/recipes-kernel/lttng/lttng-modules_git.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+python () {
+    if d.getVar("MEMF_TRACING", True) == "1":
+        d.appendVar("SRC_URI", " file://0001-lttng-adaptation-layer-for-memf-tracing.patch \
+				file://0002-lttng-adaptation-layer-for-memf-synchronization.patch \
+				file://0003-enable-building-the-added-lttng-modules.patch \
+				")
+    return
+}


### PR DESCRIPTION
This will build the required lttng modules for MEL side tracing of MEMF.

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>