### PR TITLE
linux-mel: fix indent in anonymous python function

### DIFF
--- a/zynqmp-mel-memf/recipes-kernel/linux/linux-mel_git.bbappend
+++ b/zynqmp-mel-memf/recipes-kernel/linux/linux-mel_git.bbappend
@@ -1,11 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 python () {
-	if d.getVar("MEMF_TRACING", True) == "1":
-	d.appendVar("SRC_URI", " \
-		file://0001-linux-mel-define-kernel-tracepoints-for-MEL.patch \
-		file://0002-memf-common-tracepoints.patch \
-		file://0003-memf-tracepoints-for-R5-remote-driver.patch \
-		"
-	return
+    if d.getVar("MEMF_TRACING", True) == "1":
+        d.appendVar("SRC_URI", " file://0001-linux-mel-define-kernel-tracepoints-for-MEL.patch \
+                         file://0002-memf-common-tracepoints.patch \
+                         file://0003-memf-tracepoints-for-R5-remote-driver.patch")
+    return
 }


### PR DESCRIPTION
This was supposed to go with 615a279; fix indentation in
the bbappend to fix the function.

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>