### PR TITLE
gstreamer1.0: fix QA patch warnings

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0/0001-Add-optional-LTTng-support-in-configure.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0/0001-Add-optional-LTTng-support-in-configure.patch
@@ -8,10 +8,10 @@ Subject: [PATCH 01/11] Add optional LTTng support in configure.
  1 file changed, 21 insertions(+)
 
 diff --git a/configure.ac b/configure.ac
-index e366ff1..087f80a 100644
+index 7b050ac..81d3b66 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -765,6 +765,26 @@ if test "x${GST_DISABLE_GST_DEBUG}" != "xyes"; then
+@@ -800,6 +800,26 @@ if test "x${GST_DISABLE_GST_DEBUG}" != "xyes"; then
    AC_TYPE_SIZE_T
  fi
  
@@ -38,8 +38,8 @@ index e366ff1..087f80a 100644
  dnl *** checks for dependency libraries ***
  
  dnl GLib
-@@ -1100,6 +1120,7 @@ Configuration
- 	PTP clock support          : ${HAVE_PTP}
+@@ -1157,6 +1177,7 @@ Configuration
+ 	libdw support              : ${HAVE_DW}
  
  	Debug                      : ${USE_DEBUG}
 +	LTTng tracepoints          : ${enable_lttng_tracepoints}

--- a/recipes-multimedia/gstreamer/gstreamer1.0/0010-Added-gst_latency_measurement_start-end-passed-event.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0/0010-Added-gst_latency_measurement_start-end-passed-event.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 10/11] Added gst_latency_measurement_start/end/passed events.
  2 files changed, 16 insertions(+)
 
 diff --git a/gst/gst_tracepoints.c b/gst/gst_tracepoints.c
-index aea8858..6c91a2f 100644
+index 652842a..7efee19 100644
 --- a/gst/gst_tracepoints.c
 +++ b/gst/gst_tracepoints.c
 @@ -33,6 +33,7 @@
@@ -18,10 +18,10 @@ index aea8858..6c91a2f 100644
  enum GstFlowTracepointType;
 +static const gchar *gst_tracepoints_get_pad_element_name (GstPad * pad);
  static const gchar *gst_tracepoints_get_pad_element_name_if_needed (GstPad *
-     pad, enum GstFlowTracepointType tracepoint_type);
+    pad, enum GstFlowTracepointType tracepoint_type);
  static guint16 gst_tracepoints_get_thread_id (void);
 diff --git a/gst/gst_tracepoints.h b/gst/gst_tracepoints.h
-index 6c6580f..103c45c 100644
+index 67a26a6..fed35fa 100644
 --- a/gst/gst_tracepoints.h
 +++ b/gst/gst_tracepoints.h
 @@ -134,6 +134,21 @@ GST_TRACEPOINT_EVENT (gst_flow_event_caps,


### PR DESCRIPTION
This fixes the fuzz warnings that are seen during do_patch.
The exact warnings are

WARNING: gstreamer1.0-1.12.4-r0 do_patch:
Some of the context lines in patches were ignored. This can lead to incorrectly applied patches.
The context lines in the patches can be updated with devtool:
...
Details:
Applying patch 0001-Add-optional-LTTng-support-in-configure.patch
patching file configure.ac
Hunk #1 succeeded at 800 (offset 35 lines).
Hunk #2 succeeded at 1177 with fuzz 1 (offset 57 lines).
...
Details:
Applying patch 0010-Added-gst_latency_measurement_start-end-passed-event.patch
patching file gst/gst_tracepoints.c
Hunk #1 succeeded at 33 with fuzz 2.
patching file gst/gst_tracepoints.h

Signed-off-by: Awais Belal <awais_belal@mentor.com>