### PR TITLE
0001-add_tracepoint_layer.patch: do_patch warning removal for qtquick1

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtquick1/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtquick1/0001-add_tracepoint_layer.patch
@@ -1,8 +1,8 @@
 diff --git a/src/declarative/declarative.pro b/src/declarative/declarative.pro
-index 70bfd35..f2db3b5 100644
+index 32113b6..59b6dcc 100644
 --- a/src/declarative/declarative.pro
 +++ b/src/declarative/declarative.pro
-@@ -27,6 +27,7 @@ include(qml/qml.pri)
+@@ -22,6 +22,7 @@ include(qml/qml.pri)
  include(util/util.pri)
  include(graphicsitems/graphicsitems.pri)
  include(debugger/debugger.pri)
@@ -11,10 +11,10 @@ index 70bfd35..f2db3b5 100644
  HEADERS += \
      qtdeclarativeglobal.h \
 diff --git a/src/declarative/qml/qdeclarativebinding.cpp b/src/declarative/qml/qdeclarativebinding.cpp
-index cdfb5ce..5b1e16c 100644
+index 76a9aac..ee3eb4e 100644
 --- a/src/declarative/qml/qdeclarativebinding.cpp
 +++ b/src/declarative/qml/qdeclarativebinding.cpp
-@@ -55,6 +55,10 @@
+@@ -47,6 +47,10 @@
  #include <QVariant>
  #include <QtCore/qdebug.h>
  
@@ -25,7 +25,7 @@ index cdfb5ce..5b1e16c 100644
  QT_BEGIN_NAMESPACE
  
  QDeclarativeAbstractBinding::QDeclarativeAbstractBinding()
-@@ -338,6 +342,10 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -331,6 +335,10 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
          return;
  
      if (!d->updating) {
@@ -36,7 +36,7 @@ index cdfb5ce..5b1e16c 100644
          QDeclarativeBindingProfiler prof(this);
          d->updating = true;
          bool wasDeleted = false;
-@@ -355,8 +363,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -348,8 +356,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
                                    QMetaObject::WriteProperty,
                                    idx, a);
  
@@ -51,7 +51,7 @@ index cdfb5ce..5b1e16c 100644
  
          } else {
              QDeclarativeEnginePrivate *ep = QDeclarativeEnginePrivate::get(d->context()->engine);
-@@ -365,8 +378,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -358,8 +371,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
              QVariant value;
  
              QScriptValue scriptValue = d->scriptValue(0, &isUndefined);
@@ -66,7 +66,7 @@ index cdfb5ce..5b1e16c 100644
  
              if (d->property.propertyTypeCategory() == QDeclarativeProperty::List) {
                  value = ep->scriptValueToVariant(scriptValue, qMetaTypeId<QList<QObject *> >());
-@@ -421,8 +439,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -414,8 +432,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
              } else if (d->property.object() &&
                         !QDeclarativePropertyPrivate::write(d->property, value, flags)) {
  
@@ -81,7 +81,7 @@ index cdfb5ce..5b1e16c 100644
  
                  QUrl url = QUrl(d->url);
                  int line = d->line;
-@@ -441,7 +464,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -434,7 +457,13 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
              }
  
              if (wasDeleted)
@@ -95,7 +95,7 @@ index cdfb5ce..5b1e16c 100644
  
              if (d->error.isValid()) {
                 if (!d->addError(ep)) ep->warning(this->error());
-@@ -452,6 +481,10 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
+@@ -445,6 +474,10 @@ void QDeclarativeBinding::update(QDeclarativePropertyPrivate::WriteFlags flags)
  
          d->updating = false;
          d->deleted = 0;
@@ -107,10 +107,10 @@ index cdfb5ce..5b1e16c 100644
          qmlInfo(d->property.object()) << tr("Binding loop detected for property \"%1\"").arg(d->property.name());
      }
 diff --git a/src/declarative/qml/qdeclarativecompiledbindings.cpp b/src/declarative/qml/qdeclarativecompiledbindings.cpp
-index 5546a5e..0f3fd14 100644
+index 081c4e0..39d2084 100644
 --- a/src/declarative/qml/qdeclarativecompiledbindings.cpp
 +++ b/src/declarative/qml/qdeclarativecompiledbindings.cpp
-@@ -57,6 +57,10 @@
+@@ -49,6 +49,10 @@
  #include <private/qdeclarativefastproperties_p.h>
  #include <private/qdeclarativedebugtrace_p.h>
  
@@ -121,8 +121,8 @@ index 5546a5e..0f3fd14 100644
  QT_BEGIN_NAMESPACE
  
  DEFINE_BOOL_CONFIG_OPTION(qmlExperimental, QML_EXPERIMENTAL);
-@@ -379,6 +383,10 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
-     if (!context || !context->isValid()) 
+@@ -371,6 +375,10 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
+     if (!context || !context->isValid())
          return;
  
 +#ifdef ENABLE_SA_TRACE
@@ -132,7 +132,7 @@ index 5546a5e..0f3fd14 100644
      if (binding->updating) {
          QString name;
          if (binding->property & 0xFFFF0000) {
-@@ -394,6 +402,11 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
+@@ -386,6 +394,11 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
              name = QLatin1String(binding->target->metaObject()->property(binding->property).name());
          }
          qmlInfo(binding->target) << QCoreApplication::translate("QDeclarativeCompiledBindings", "Binding loop detected for property \"%1\"").arg(name);
@@ -144,7 +144,7 @@ index 5546a5e..0f3fd14 100644
          return;
      }
  
-@@ -413,6 +426,10 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
+@@ -405,6 +418,10 @@ void QDeclarativeCompiledBindingsPrivate::run(Binding *binding, QDeclarativeProp
          run(binding->index, context, binding, binding->scope, binding->target, flags);
      }
      binding->updating = false;
@@ -156,10 +156,10 @@ index 5546a5e..0f3fd14 100644
  
  namespace {
 diff --git a/src/declarative/qml/qdeclarativecomponent.cpp b/src/declarative/qml/qdeclarativecomponent.cpp
-index cbf23fa..226473c 100644
+index cf89a5f..c6cd71f 100644
 --- a/src/declarative/qml/qdeclarativecomponent.cpp
 +++ b/src/declarative/qml/qdeclarativecomponent.cpp
-@@ -62,6 +62,10 @@
+@@ -54,6 +54,10 @@
  #include <QApplication>
  #include <qdeclarativeinfo.h>
  
@@ -170,7 +170,7 @@ index cbf23fa..226473c 100644
  QT_BEGIN_NAMESPACE
  
  class QByteArray;
-@@ -850,6 +854,10 @@ QObject * QDeclarativeComponentPrivate::begin(QDeclarativeContextData *parentCon
+@@ -842,6 +846,10 @@ QObject * QDeclarativeComponentPrivate::begin(QDeclarativeContextData *parentCon
      Q_ASSERT((state != 0) ^ (errors != 0)); // One of state or errors (but not both) must be provided
  
      if (isRoot) {
@@ -181,7 +181,7 @@ index cbf23fa..226473c 100644
          QDeclarativeDebugTrace::startRange(QDeclarativeDebugTrace::Creating);
          QDeclarativeDebugTrace::rangeData(QDeclarativeDebugTrace::Creating, component->url);
      }
-@@ -1044,6 +1052,10 @@ void QDeclarativeComponentPrivate::completeCreate()
+@@ -1036,6 +1044,10 @@ void QDeclarativeComponentPrivate::completeCreate()
          complete(ep, &state);
  
          QDeclarativeDebugTrace::endRange(QDeclarativeDebugTrace::Creating);
@@ -193,10 +193,10 @@ index cbf23fa..226473c 100644
  }
  
 diff --git a/src/declarative/qml/qdeclarativeengine.cpp b/src/declarative/qml/qdeclarativeengine.cpp
-index c7fc386..2f6ba37 100644
+index af6c7aa..eccad29 100644
 --- a/src/declarative/qml/qdeclarativeengine.cpp
 +++ b/src/declarative/qml/qdeclarativeengine.cpp
-@@ -113,6 +113,11 @@
+@@ -105,6 +105,11 @@
  #define CSIDL_APPDATA		0x001a	// <username>\Application Data
  #endif
  
@@ -208,7 +208,7 @@ index c7fc386..2f6ba37 100644
  Q_DECLARE_METATYPE(QDeclarativeProperty)
  Q_DECLARE_METATYPE(QScriptValue)
  
-@@ -1023,6 +1028,10 @@ void qmlExecuteDeferred(QObject *object)
+@@ -1015,6 +1020,10 @@ void qmlExecuteDeferred(QObject *object)
      QDeclarativeData *data = QDeclarativeData::get(object);
  
      if (data && data->deferredComponent) {
@@ -219,7 +219,7 @@ index c7fc386..2f6ba37 100644
          if (QDeclarativeDebugService::isDebuggingEnabled()) {
              QDeclarativeDebugTrace::startRange(QDeclarativeDebugTrace::Creating);
              QDeclarativeType *type = QDeclarativeMetaType::qmlType(object->metaObject());
-@@ -1041,6 +1050,10 @@ void qmlExecuteDeferred(QObject *object)
+@@ -1033,6 +1042,10 @@ void qmlExecuteDeferred(QObject *object)
  
          QDeclarativeComponentPrivate::complete(ep, &state);
          QDeclarativeDebugTrace::endRange(QDeclarativeDebugTrace::Creating);
@@ -231,10 +231,10 @@ index c7fc386..2f6ba37 100644
  }
  
 diff --git a/src/declarative/qml/qdeclarativetypeloader.cpp b/src/declarative/qml/qdeclarativetypeloader.cpp
-index 42847ea..09ea93b 100644
+index 1100a12..d640d9b 100644
 --- a/src/declarative/qml/qdeclarativetypeloader.cpp
 +++ b/src/declarative/qml/qdeclarativetypeloader.cpp
-@@ -53,6 +53,10 @@
+@@ -45,6 +45,10 @@
  #include <QtCore/qdiriterator.h>
  #include <QtCore/qfile.h>
  
@@ -245,7 +245,7 @@ index 42847ea..09ea93b 100644
  QT_BEGIN_NAMESPACE
  
  /*
-@@ -528,14 +532,24 @@ void QDeclarativeDataLoader::load(QDeclarativeDataBlob *blob)
+@@ -520,14 +524,24 @@ void QDeclarativeDataLoader::load(QDeclarativeDataBlob *blob)
  
      QString lf = QDeclarativeEnginePrivate::urlToLocalFileOrQrc(blob->m_url);
  
@@ -270,7 +270,7 @@ index 42847ea..09ea93b 100644
          QFile file(lf);
          if (file.open(QFile::ReadOnly)) {
              QByteArray data = file.readAll();
-@@ -544,6 +558,10 @@ void QDeclarativeDataLoader::load(QDeclarativeDataBlob *blob)
+@@ -536,6 +550,10 @@ void QDeclarativeDataLoader::load(QDeclarativeDataBlob *blob)
              blob->downloadProgressChanged(1.);
  
              setData(blob, data);
@@ -281,7 +281,7 @@ index 42847ea..09ea93b 100644
          } else {
              blob->networkError(QNetworkReply::ContentNotFoundError);
          }
-@@ -602,6 +620,10 @@ void QDeclarativeDataLoader::networkReplyFinished(QNetworkReply *reply)
+@@ -594,6 +612,10 @@ void QDeclarativeDataLoader::networkReplyFinished(QNetworkReply *reply)
          setData(blob, data);
      }
  
@@ -292,7 +292,7 @@ index 42847ea..09ea93b 100644
      blob->release();
  }
  
-@@ -922,6 +944,10 @@ void QDeclarativeTypeData::unregisterCallback(TypeDataCallback *callback)
+@@ -914,6 +936,10 @@ void QDeclarativeTypeData::unregisterCallback(TypeDataCallback *callback)
  
  void QDeclarativeTypeData::done()
  {
@@ -303,7 +303,7 @@ index 42847ea..09ea93b 100644
      addref();
  
      // Check all script dependencies for errors
-@@ -1034,6 +1060,11 @@ void QDeclarativeTypeData::downloadProgressChanged(qreal p)
+@@ -1026,6 +1052,11 @@ void QDeclarativeTypeData::downloadProgressChanged(qreal p)
  void QDeclarativeTypeData::compile()
  {
      Q_ASSERT(m_compiledData == 0);
@@ -315,7 +315,7 @@ index 42847ea..09ea93b 100644
      QDeclarativeDebugTrace::startRange(QDeclarativeDebugTrace::Compiling);
  
      m_compiledData = new QDeclarativeCompiledData(typeLoader()->engine());
-@@ -1048,6 +1079,10 @@ void QDeclarativeTypeData::compile()
+@@ -1040,6 +1071,10 @@ void QDeclarativeTypeData::compile()
          m_compiledData = 0;
      }
      QDeclarativeDebugTrace::endRange(QDeclarativeDebugTrace::Compiling);


### PR DESCRIPTION

Warning from do_patch was:

WARNING: qtquick1-5.6.3+gitAUTOINC+b934c54583-r0 do_patch: 
Some of the context lines in patches were ignored. This can lead to incorrectly applied patches.
The context lines in the patches can be updated with devtool:
    devtool modify <recipe>
    devtool finish --force-patch-refresh <recipe> <layer_path>
Then the updated patches and the source tree (in devtool's workspace)
should be reviewed to make sure the patches apply in the correct place
and don't introduce duplicate lines (which can, and does happen
when some of the context is ignored). Further information:
http://lists.openembedded.org/pipermail/openembedded-core/2018-March/148675.html
https://bugzilla.yoctoproject.org/show_bug.cgi?id=10450
Details:
Applying patch 0001-add_tracepoint_layer.patch
patching file src/declarative/declarative.pro
Hunk #1 succeeded at 22 (offset -5 lines).
patching file src/declarative/qml/qdeclarativebinding.cpp
Hunk #1 succeeded at 47 (offset -8 lines).
Hunk #2 succeeded at 335 (offset -7 lines).
Hunk #3 succeeded at 356 (offset -7 lines).
Hunk #4 succeeded at 371 (offset -7 lines).
Hunk #5 succeeded at 432 (offset -7 lines).
Hunk #6 succeeded at 457 (offset -7 lines).
Hunk #7 succeeded at 474 (offset -7 lines).
patching file src/declarative/qml/qdeclarativecompiledbindings.cpp
Hunk #1 succeeded at 49 (offset -8 lines).
Hunk #2 succeeded at 375 with fuzz 1 (offset -8 lines).
Hunk #3 succeeded at 394 (offset -8 lines).
Hunk #4 succeeded at 418 (offset -8 lines).
patching file src/declarative/qml/qdeclarativecomponent.cpp
Hunk #1 succeeded at 54 (offset -8 lines).
Hunk #2 succeeded at 846 (offset -8 lines).
Hunk #3 succeeded at 1044 (offset -8 lines).
patching file src/declarative/qml/qdeclarativeengine.cpp
Hunk #1 succeeded at 105 with fuzz 1 (offset -8 lines).
Hunk #2 succeeded at 1020 (offset -8 lines).
Hunk #3 succeeded at 1042 (offset -8 lines).
patching file src/declarative/qml/qdeclarativetypeloader.cpp
Hunk #1 succeeded at 45 (offset -8 lines).
Hunk #2 succeeded at 524 (offset -8 lines).
Hunk #3 succeeded at 550 (offset -8 lines).
Hunk #4 succeeded at 612 (offset -8 lines).
Hunk #5 succeeded at 936 (offset -8 lines).
Hunk #6 succeeded at 1052 (offset -8 lines).
Hunk #7 succeeded at 1071 (offset -8 lines).



Have updated patches according to the sources.
Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>