### PR TITLE
qtdeclarative: remove extra endif macro

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtdeclarative/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtdeclarative/0001-add_tracepoint_layer.patch
@@ -214,15 +214,13 @@ Index: git/src/quick/items/qquickwindow.cpp
 ===================================================================
 --- git.orig/src/quick/items/qquickwindow.cpp
 +++ git/src/quick/items/qquickwindow.cpp
-@@ -82,6 +82,13 @@
+@@ -82,6 +82,11 @@
  #include <private/qdebug_p.h>
  #endif
  
 +#ifdef ENABLE_SA_TRACE
 +    #define QT_TRACEPOINT_PER_LIBRARY_DEFINITION
 +    #include <sa-trace/qt_tracepoints.h>
-+#endif // ENABLE_SA_TRACE
-+
 +#endif // ENABLE_SA_TRACE
 +
  QT_BEGIN_NAMESPACE


### PR DESCRIPTION
Remove the typo of aditional #endif macro that caused build
time error.

Jira Issue: http://jira.alm.mentorg.com:8080/browse/SB-12510

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>