### PR TITLE
qtdeclarative: fix getting the source file location

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtdeclarative/0001-add_tracepoint_layer.patch
+++ b/qt5-layer/recipes-qt/qt5/qtdeclarative/0001-add_tracepoint_layer.patch
@@ -22,13 +22,12 @@ index b9566d5..9eb9c0f 100644
  QT_BEGIN_NAMESPACE
  
  QQmlBinding *QQmlBinding::create(const QQmlPropertyData *property, const QQmlScriptString &script, QObject *obj, QQmlContext *ctxt)
-@@ -180,6 +184,12 @@ void QQmlBinding::update(QQmlPropertyData::WriteFlags flags)
+@@ -180,6 +184,11 @@ void QQmlBinding::update(QQmlPropertyData::WriteFlags flags)
      }
      setUpdatingFlag(true);
  
 +#ifdef ENABLE_SA_TRACE
-+        QQmlSourceLocation loc = function()->sourceLocation();
-+        QString url = loc.sourceFile;
++        QString url = sourceLocation().sourceFile;
 +        qt_tracepoint(Qt, qtQmlFrameBind, 1, qPrintable(url));
 +#endif // ENABLE_SA_TRACE
 +


### PR DESCRIPTION
Getting source file location in Qt has changed, so  need to update the
tracing hooks in qtdeclarative code to collect the file name and location for logs.

Now 'QQmlTranslationBinding' class provides 'QQmlSourceLocation sourceLocation()' function
that returns the source file url, earlier it can be accessed as 'function()->sourceLocation()'
but now it's an invalid operation and cause seg fault in qt applications, e.g

    [  101.177604] audit: type=1701 audit(1608650298.401:4): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=1084 comm="qt_quick_nano_2" exe="/home/root/qt_quick_nano_2" sig=11 res=1
    Segmentation fault

JIRA: https://jira.alm.mentorg.com/browse/SB-16092

Signed-off-by: Sajjad Ahmed <sajjad_ahmed@mentor.com>